### PR TITLE
Replace kbman.html link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Also check out more examples at [./examples/](./examples/).
 ## References
 
 - https://en.wikipedia.org/wiki/B_(programming_language)
-- https://web.archive.org/web/20241214022534/https://www.bell-labs.com/usr/dmr/www/kbman.html
+- https://www.nokia.com/bell-labs/about/dennis-m-ritchie/kbman.html
 - https://github.com/tsoding/good_training_language
 - https://www.felixcloutier.com/x86/
 - https://www.scs.stanford.edu/~zyedidia/arm64/


### PR DESCRIPTION
The kbman.html document is still on the bell labs server, just on a different path and there is no need for wayback machine