### PR TITLE
Fix unsigned printf for uxn

### DIFF
--- a/libb/6502.b
+++ b/libb/6502.b
@@ -136,7 +136,7 @@ printf(str, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) {
                 while (c = char(*arg, j++)) {
                     putchar(c);
                 }
-            } else if ((c == 'z') | (c == 'l')) { /* hack for %zu %lu, % */
+            } else if (c == 'z' | c == 'l') { /* hack for %zu %lu, % */
                 c = '%';
                 goto while_end;
             } else {
@@ -149,7 +149,7 @@ printf(str, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) {
         }
         i++;
         c = char(str, i);
-        while_end:
+        while_end:;
     }
 }
 

--- a/libb/uxn.b
+++ b/libb/uxn.b
@@ -21,14 +21,24 @@ abort() {
     exit(1);
 }
 
+_udiv(a, b) {
+    extrn uxn_div2;
+    return (uxn_div2(a, b));
+}
+
+// TODO: `b` has to be <32768, because of `*`
+_urem(a, b) {
+    return (a - _udiv(a, b) * b);
+}
+
 /* loosely based on the original code by Ken Thompson */
 
 _fprintn(n, b, fd) {
     auto a, c;
 
-    if(a=n/b) /* assignment, not test for equality */
+    if(a=_udiv(n,b)) /* assignment, not test for equality */
         _fprintn(a, b, fd); /* recursive */
-    c = n%b + '0';
+    c = _urem(n,b) + '0';
     if (c > '9') c += 7;
     fputc(c, fd);
 }
@@ -70,6 +80,9 @@ fprintf(fd, string, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) {
                 while (c = char(*arg, j++)) {
                     fputc(c, fd);
                 }
+            } else if (c == 'l' | c == 'z') {
+                c = '%';
+                goto continue;
             } else {
                 fputc('%', fd);
                 arg += 2; /* word size */
@@ -80,6 +93,7 @@ fprintf(fd, string, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) {
         }
         i += 1;
         c = char(string, i);
+        continue:;
     }
 }
 

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -770,6 +770,15 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
             write_lit2(output, 0);
             write_lit_stz2(output, FIRST_ARG);
             write_op(output, UxnOp::JMP2r);
+        } else if strcmp(name, c!("uxn_div2")) == 0 {
+            // uxn_udiv(a, b)
+            // outputs 16 bit unsigned division of a / b.
+            link_label(assembler, get_or_create_label_by_name(assembler, c!("uxn_div2")), (*output).count);
+            write_lit_ldz2(output, FIRST_ARG);
+            write_lit_ldz2(output, FIRST_ARG + 2);
+            write_op(output, UxnOp::DIV2);
+            write_lit_stz2(output, FIRST_ARG);
+            write_op(output, UxnOp::JMP2r);
         } else {
             log(Log_Level::ERROR, c!("uxn: Unknown extrn: `%s`, can not link"), name);
             abort();


### PR DESCRIPTION
This fixes 2 printf bugs (`%l/%z` and unsigned `_fprintn`, as #213 did for 6502) by introducing a new `uxn_div2` intrinsic for unsigned division.
Because multiplication is still signed, `_urem(a, b)` only works for `b <32768`, this could be fixed by introducing unsigned multiplication or mod.