### PR TITLE
uxn inline assembly

### DIFF
--- a/examples/uxn/callable_globals.b
+++ b/examples/uxn/callable_globals.b
@@ -1,6 +1,4 @@
 /*
-Implies -nostdlib.
-
 In B there's this strange syntax to initialize a global variable,
 and a few unnamed words after that global variable, to specific values.
 

--- a/examples/uxn/hello.b
+++ b/examples/uxn/hello.b
@@ -1,5 +1,4 @@
 /*
-Implies -nostdlib.
 Shows how to communicate with a varvara device
 */
 

--- a/examples/uxn/screen.b
+++ b/examples/uxn/screen.b
@@ -1,7 +1,3 @@
-/* IMPORTANT! Implies -nostdlib.
- * Because the entry point from ./libb/uxn.b conflicts with the entry point of this program.
- * TODO: do we want to do anything about this?
- */
 logo;
 
 x; y;
@@ -49,6 +45,7 @@ on_screen() {
 
 main() {
     extrn uxn_deo2, lchar;
+    uxn_disable_exit_after_main();
     logo = "aaaaaaaaaaaaaaaa";
     lchar(logo,  0, 0x00); lchar(logo,  8, 0x7e); /*  ######  */
     lchar(logo,  1, 0x38); lchar(logo,  9, 0xc7); /* ##...### */

--- a/libb/uxn.b
+++ b/libb/uxn.b
@@ -115,6 +115,18 @@ exit(code) {
     uxn_deo(0x0f, code | 0x80); /* System/state */
 }
 
+_exit_after_main 1;
+
+uxn_disable_exit_after_main() {
+    _exit_after_main = 0;
+}
+
+_exit_main(code) {
+    if (_exit_after_main) {
+        exit(code);
+    }
+}
+
 abort() {
     extrn printf;
     printf("Aborted\n");
@@ -260,7 +272,7 @@ _start_with_arguments() {
     } else if (type == 4) { /* arguments end */
         lchar(__alloc_ptr++, 0, 0);
         uxn_deo2(0x10, 0);
-        exit(main(_args_count, _args_items));
+        _exit_main(main(_args_count, _args_items));
     }
 }
 
@@ -277,7 +289,7 @@ _start() {
         *(_args_items + (_args_count++)*2) = __alloc_ptr;
         uxn_deo2(0x10, &_start_with_arguments);
     } else {
-        exit(main(_args_count, _args_items));
+        _exit_main(main(_args_count, _args_items));
     }
 }
 

--- a/libb/uxn.b
+++ b/libb/uxn.b
@@ -1,5 +1,105 @@
 /* Standard Library for the Uxn target */
 
+/*
+ch = char(string, i);
+returns the ith character in a string pointed to by string, 0 based
+*/
+
+char __asm__(
+    "lit 4", "ldz2", /* first arg, string */
+    "lit 6", "ldz2", /* second arg, i */
+    "add2",
+    "lda",
+    "lit 0",
+    "swp",
+    "lit 4", "stz2", /* return value (same spot as the first arg) */
+    "jmp2r"
+);
+
+/*
+ch = lchar(string, i, char);
+replaces the ith character in the string pointed to by string with the character char.
+The value LCHAR returns is the character char that was placed in the string.
+*/
+
+lchar __asm__(
+    "lit 9", "ldz", /* low byte of the arg 2, char */
+    "lit 4", "ldz2",
+    "lit 6", "ldz2",
+    "add2",
+    "stak",
+    "pop2",
+    "lit 0",
+    "swp",
+    "lit 4", "stz2",
+    "jmp2r"
+);
+
+/*
+value = uxn_dei(device);
+reads 8 bit value off a device
+*/
+
+uxn_dei __asm__(
+    "lit 0", "lit 4", "stz", /* zero the high byte of arg0/return */
+    "lit 5", "ldzk", /* low byte of arg0 */
+    "dei",
+    "swp",
+    "stz",
+    "jmp2r"
+);
+
+/*
+value = uxn_dei2(device);
+reads 16 bit value off a device
+*/
+
+uxn_dei2 __asm__(
+    "lit 5", "ldz", /* low byte of arg0 */
+    "dei2",
+    "lit 4", "stz2",
+    "jmp2r"
+);
+
+/*
+uxn_deo(device, value);
+outputs 8 bit value to a device
+*/
+
+uxn_deo __asm__(
+    "lit 7", "ldz", /* low byte of arg1 */
+    "lit 5", "ldz", /* low byte of arg0 */
+    "deo",
+    "lit2 0", "lit 4", "stz2", /* return 0 */
+    "jmp2r"
+);
+
+/*
+uxn_deo2(device, value);
+outputs 16 bit value to a device
+*/
+
+uxn_deo2 __asm__(
+    "lit 6", "ldz2", /* arg1 */
+    "lit 5", "ldz", /* low byte of arg0 */
+    "deo2",
+    "lit2 0", "lit 4", "stz2", /* return 0 */
+    "jmp2r"
+);
+
+/*
+uxn_udiv(a, b)
+outputs 16 bit unsigned division of a / b.
+*/
+
+uxn_div2 __asm__(
+    "lit 4", "ldz2", /* arg0 */
+    "lit 6", "ldz2", /* arg1 */
+    "div2",
+    "lit 4", "stz2",
+    "jmp2r"
+);
+
 fputc(c, fd) {
     extrn uxn_deo;
     uxn_deo(fd + 0x18, c); /* 0x18 - Console/write,

--- a/src/codegen/gas_x86_64.rs
+++ b/src/codegen/gas_x86_64.rs
@@ -672,11 +672,11 @@ pub unsafe fn generate_program(
     gen: *mut c_void, program: *const Program, program_path: *const c_char, garbage_base: *const c_char, os: Os,
     nostdlib: bool, debug: bool,
 ) -> Option<()> {
-    if debug { generate_debuginfo(output, (*program).funcs, (*program).globals, os); }
-
     let gen = gen as *mut Gas_x86_64;
     let output = &mut (*gen).output;
     let cmd = &mut (*gen).cmd;
+
+    if debug { generate_debuginfo(output, (*program).funcs, (*program).globals, os); }
 
     match os {
         Os::Darwin => sb_appendf(output, c!(".text\n")),

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -77,7 +77,7 @@ pub unsafe fn link_label(a: *mut Assembler, label: usize, addr: usize) {
     *(*a).resolved_addresses.items.add(label) = addr as u16;
 }
 
-pub unsafe fn apply_patches(output: *mut String_Builder, a: *mut Assembler) {
+pub unsafe fn apply_patches(output: *mut String_Builder, a: *mut Assembler) -> Option<()> {
     for i in 0..(*a).patches.count {
         let patch = *(*a).patches.items.add(i);
         let addr = *(*a).resolved_addresses.items.add(patch.label);
@@ -86,11 +86,11 @@ pub unsafe fn apply_patches(output: *mut String_Builder, a: *mut Assembler) {
                 let named_label = *(*a).named_labels.items.add(j);
                 if named_label.label == patch.label {
                     log(Log_Level::ERROR, c!("uxn: Label '%s' was never linked"), named_label.name);
-                    abort();
+                    return None;
                 }
             }
             log(Log_Level::ERROR, c!("uxn: Label #%ld was never linked"), patch.label);
-            abort();
+            return None;
         }
         let offset = patch.offset;
         let byte = match patch.kind {
@@ -101,18 +101,20 @@ pub unsafe fn apply_patches(output: *mut String_Builder, a: *mut Assembler) {
         };
         *(*output).items.add(patch.addr as usize) = byte as c_char;
     }
+    Some(())
 }
 
 const SP: u8 = 0;
 const BP: u8 = 2;
 const FIRST_ARG: u8 = 4;
 
-pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const [AsmFunc], assembler: *mut Assembler) {
+pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const [AsmFunc], assembler: *mut Assembler) -> Option<()> {
     for i in 0..asm_funcs.len() {
         let asm_func = (*asm_funcs)[i];
         link_label(assembler, get_or_create_label_by_name(assembler, asm_func.name), (*output).count);
-        process_asm_statements(output, da_slice(asm_func.body), assembler);
+        process_asm_statements(output, da_slice(asm_func.body), assembler)?;
     }
+    Some(())
 }
 
 pub unsafe fn usage(params: *const [Param]) {
@@ -237,13 +239,13 @@ pub unsafe fn generate_program(
     write_label_abs(output, vector_return_label, &mut assembler, 0);
     write_op(output, UxnOp::BRK);
 
-    generate_funcs(output, da_slice((*program).funcs), &mut assembler);
-    generate_asm_funcs(output, da_slice((*program).asm_funcs), &mut assembler);
-    generate_extrns(output, da_slice((*program).extrns), da_slice((*program).funcs), da_slice((*program).globals), &mut assembler);
+    generate_funcs(output, da_slice((*program).funcs), &mut assembler)?;
+    generate_asm_funcs(output, da_slice((*program).asm_funcs), &mut assembler)?;
+    generate_extrns(output, da_slice((*program).extrns), da_slice((*program).funcs), da_slice((*program).globals), &mut assembler)?;
     generate_data_section(output, da_slice((*program).data), &mut assembler);
     generate_globals(output, da_slice((*program).globals), &mut assembler);
 
-    apply_patches(output, &mut assembler);
+    apply_patches(output, &mut assembler)?;
 
     write_entire_file(program_path, (*output).items as *const c_void, (*output).count)?;
     log(Log_Level::INFO, c!("generated %s"), program_path);
@@ -264,13 +266,14 @@ pub unsafe fn run_program(
     Some(())
 }
 
-pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], assembler: &mut Assembler) {
+pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], assembler: &mut Assembler) -> Option<()> {
     for i in 0..funcs.len() {
-        generate_function((*funcs)[i].name, (*funcs)[i].name_loc, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output, assembler);
+        generate_function((*funcs)[i].name, (*funcs)[i].name_loc, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output, assembler)?;
     }
+    Some(())
 }
 
-pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count: usize, auto_vars_count: usize, body: *const [OpWithLocation], output: *mut String_Builder, assembler: *mut Assembler) {
+pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count: usize, auto_vars_count: usize, body: *const [OpWithLocation], output: *mut String_Builder, assembler: *mut Assembler) -> Option<()> {
     link_label(assembler, get_or_create_label_by_name(assembler, name), (*output).count);
 
     const MAX_ARGS: usize = (256 - FIRST_ARG as usize) / 2;
@@ -589,7 +592,7 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 store_auto(output, result);
             }
             Op::Asm {stmts} => {
-                process_asm_statements(output, da_slice(stmts), assembler);
+                process_asm_statements(output, da_slice(stmts), assembler)?;
             }
             Op::Label {label} => {
                 link_label(assembler, *labels.items.add(label), (*output).count);
@@ -662,6 +665,8 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
 
     // return
     write_op(output, UxnOp::JMP2r);
+
+    Some(())
 }
 
 pub unsafe fn write_op(output: *mut String_Builder, op: UxnOp) {
@@ -803,7 +808,7 @@ pub unsafe fn store_auto(output: *mut String_Builder, index: usize) {
     write_op(output, UxnOp::STA2);
 }
 
-pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*const c_char], funcs: *const [Func], globals: *const [Global], assembler: *mut Assembler) {
+pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*const c_char], funcs: *const [Func], globals: *const [Global], assembler: *mut Assembler) -> Option<()> {
     'skip_function_or_global: for i in 0..extrns.len() {
         // assemble a few "stdlib" functions which can't be programmed in B
         let name = (*extrns)[i];
@@ -904,9 +909,10 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
             write_op(output, UxnOp::JMP2r);
         } else {
             log(Log_Level::ERROR, c!("uxn: Unknown extrn: `%s`, can not link"), name);
-            abort();
+            return None;
         }
     }
+    Some(())
 }
 
 pub unsafe fn generate_globals(output: *mut String_Builder, globals: *const [Global], assembler: *mut Assembler) {
@@ -1279,14 +1285,15 @@ pub unsafe fn has_immediate(op: UxnOp) -> bool {
     has_byte_immediate(op) || has_short_immediate(op)
 }
 
-pub unsafe fn process_asm_statements(output: *mut String_Builder, asm_stmts: *const [AsmStmt], assembler: *mut Assembler) {
+pub unsafe fn process_asm_statements(output: *mut String_Builder, asm_stmts: *const [AsmStmt], assembler: *mut Assembler) -> Option<()> {
     for i in 0..asm_stmts.len() {
         let asm_stmt = (*asm_stmts)[i];
-        process_asm_statement(output, asm_stmt, assembler);
+        process_asm_statement(output, asm_stmt, assembler)?;
     }
+    Some(())
 }
 
-pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmStmt, assembler: *mut Assembler) {
+pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmStmt, assembler: *mut Assembler) -> Option<()> {
     // TODO: leaky function, but beware holding onto strings produced by the lexer
 
     let mut lexer_name: String_Builder = zeroed();
@@ -1294,44 +1301,44 @@ pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmSt
     da_append(&mut lexer_name, 0);
     let mut l = lexer::new(lexer_name.items, asm_stmt.line, asm_stmt.line.add(strlen(asm_stmt.line)), false);
     let saved_point = l.parse_point;
-    lexer::get_token(&mut l).expect("Lexing error");
+    lexer::get_token(&mut l)?;
     match l.token {
         Token::EOF => { /* Allow empty asm line, not sure if useful */ }
         Token::ID => {
             // label or opcode
-            lexer::get_token(&mut l).expect("Lexing error");
+            lexer::get_token(&mut l)?;
             match l.token {
                 Token::Colon => {
                     // label
                     link_label(assembler, get_or_create_label_by_name(assembler, l.string), (*output).count);
-                    lexer::get_token(&mut l).expect("Lexing error");
+                    lexer::get_token(&mut l)?;
                     match l.token {
                         Token::ID => { /* must be an an opcode */ }
-                        Token::EOF => { return; }
+                        Token::EOF => { return Some(()); }
                         _ => {
                             diagf!(loc(&mut l), c!("ERROR: expected %s but got %s\n"),
                                 lexer::display_token(Token::ID),
                                 lexer::display_token(l.token));
-                            abort();
+                            return None;
                         }
                     }
                 }
                 _ => {
                     l.parse_point = saved_point;
-                    lexer::get_token(&mut l).expect("Lexing error");
+                    lexer::get_token(&mut l)?;
                 }
             }
         }
         _ => {
             diagf!(loc(&mut l), c!("ERROR: expected %s but got %s\n"),
                 lexer::display_token(Token::ID), lexer::display_token(l.token));
-            abort();
+            return None;
         }
     }
     // must be an opcode
     if let Some(opcode) = find_opcode_by_name(l.string) {
         write_op(output, opcode);
-        lexer::get_token(&mut l).expect("Lexing error");
+        lexer::get_token(&mut l)?;
         if has_immediate(opcode) {
             match l.token {
                 Token::ID => {
@@ -1345,7 +1352,7 @@ pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmSt
                         }
                     } else {
                         diagf!(loc(&mut l), c!("ERROR: label is not a valid short immediate\n"));
-                        abort();
+                        return None;
                     }
                 }
                 Token::IntLit | Token::CharLit => {
@@ -1362,30 +1369,30 @@ pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmSt
                         lexer::display_token(Token::IntLit),
                         lexer::display_token(Token::CharLit),
                         lexer::display_token(l.token));
-                    abort();
+                    return None;
                 }
             }
         } else {
             match l.token {
-                Token::EOF => { return; }
+                Token::EOF => { return Some(()); }
                 _ => {
                     diagf!(loc(&mut l), c!("ERROR: expected end of the line but got %s\n"),
                         lexer::display_token(l.token));
-                    abort();
+                    return None;
                 }
             }
         }
     } else {
         diagf!(loc(&mut l), c!("ERROR: invalid uxn opcode: %s\n"), l.string);
-        abort();
+        return None;
     }
-    lexer::get_token(&mut l).expect("Lexing error");
+    lexer::get_token(&mut l)?;
     match l.token {
-        Token::EOF => { return; }
+        Token::EOF => { return Some(()); }
         _ => {
             diagf!(loc(&mut l), c!("ERROR: expected nothing but got %s\n"),
                 lexer::display_token(l.token));
-            abort();
+            return None;
         }
     }
 }

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -8,6 +8,8 @@ use crate::missingf;
 use crate::diagf;
 use crate::arena;
 use crate::codegen::*;
+use crate::lexer;
+use crate::lexer::{Token, loc};
 
 // UXN memory map
 // 0x0000 - 0x00ff - zero page
@@ -105,10 +107,11 @@ const SP: u8 = 0;
 const BP: u8 = 2;
 const FIRST_ARG: u8 = 4;
 
-pub unsafe fn generate_asm_funcs(_output: *mut String_Builder, asm_funcs: *const [AsmFunc]) {
+pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const [AsmFunc], assembler: *mut Assembler) {
     for i in 0..asm_funcs.len() {
         let asm_func = (*asm_funcs)[i];
-        missingf!(asm_func.name_loc, c!("__asm__ functions for uxn"));
+        link_label(assembler, get_or_create_label_by_name(assembler, asm_func.name), (*output).count);
+        process_asm_statements(output, da_slice(asm_func.body), assembler);
     }
 }
 
@@ -235,7 +238,7 @@ pub unsafe fn generate_program(
     write_op(output, UxnOp::BRK);
 
     generate_funcs(output, da_slice((*program).funcs), &mut assembler);
-    generate_asm_funcs(output, da_slice((*program).asm_funcs));
+    generate_asm_funcs(output, da_slice((*program).asm_funcs), &mut assembler);
     generate_extrns(output, da_slice((*program).extrns), da_slice((*program).funcs), da_slice((*program).globals), &mut assembler);
     generate_data_section(output, da_slice((*program).data), &mut assembler);
     generate_globals(output, da_slice((*program).globals), &mut assembler);
@@ -585,7 +588,9 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 write_lit_ldz2(output, FIRST_ARG);
                 store_auto(output, result);
             }
-            Op::Asm {..} => missingf!(op.loc, c!("Inline assembly\n")),
+            Op::Asm {stmts} => {
+                process_asm_statements(output, da_slice(stmts), assembler);
+            }
             Op::Label {label} => {
                 link_label(assembler, *labels.items.add(label), (*output).count);
             }
@@ -940,7 +945,7 @@ pub unsafe fn generate_data_section(output: *mut String_Builder, data: *const [u
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum UxnOp {
     BRK    = 0x00,
     INC    = 0x01,
@@ -1198,4 +1203,189 @@ pub enum UxnOp {
     ORA2kr = 0xfd,
     EOR2kr = 0xfe,
     SFT2kr = 0xff,
+}
+
+pub const AsmOpNames: *const [*const c_char] = &[
+    c!("brk"),    c!("inc"),    c!("pop"),    c!("nip"),    c!("swp"),    c!("rot"),    c!("dup"),    c!("ovr"),
+    c!("equ"),    c!("neq"),    c!("gth"),    c!("lth"),    c!("jmp"),    c!("jcn"),    c!("jsr"),    c!("sth"),
+    c!("ldz"),    c!("stz"),    c!("ldr"),    c!("str"),    c!("lda"),    c!("sta"),    c!("dei"),    c!("deo"),
+    c!("add"),    c!("sub"),    c!("mul"),    c!("div"),    c!("and"),    c!("ora"),    c!("eor"),    c!("sft"),
+    c!("jci"),    c!("inc2"),   c!("pop2"),   c!("nip2"),   c!("swp2"),   c!("rot2"),   c!("dup2"),   c!("ovr2"),
+    c!("equ2"),   c!("neq2"),   c!("gth2"),   c!("lth2"),   c!("jmp2"),   c!("jcn2"),   c!("jsr2"),   c!("sth2"),
+    c!("ldz2"),   c!("stz2"),   c!("ldr2"),   c!("str2"),   c!("lda2"),   c!("sta2"),   c!("dei2"),   c!("deo2"),
+    c!("add2"),   c!("sub2"),   c!("mul2"),   c!("div2"),   c!("and2"),   c!("ora2"),   c!("eor2"),   c!("sft2"),
+    c!("jmi"),    c!("incr"),   c!("popr"),   c!("nipr"),   c!("swpr"),   c!("rotr"),   c!("dupr"),   c!("ovrr"),
+    c!("equr"),   c!("neqr"),   c!("gthr"),   c!("lthr"),   c!("jmpr"),   c!("jcnr"),   c!("jsrr"),   c!("sthr"),
+    c!("ldzr"),   c!("stzr"),   c!("ldrr"),   c!("strr"),   c!("ldar"),   c!("star"),   c!("deir"),   c!("deor"),
+    c!("addr"),   c!("subr"),   c!("mulr"),   c!("divr"),   c!("andr"),   c!("orar"),   c!("eorr"),   c!("sftr"),
+    c!("jsi"),    c!("inc2r"),  c!("pop2r"),  c!("nip2r"),  c!("swp2r"),  c!("rot2r"),  c!("dup2r"),  c!("ovr2r"),
+    c!("equ2r"),  c!("neq2r"),  c!("gth2r"),  c!("lth2r"),  c!("jmp2r"),  c!("jcn2r"),  c!("jsr2r"),  c!("sth2r"),
+    c!("ldz2r"),  c!("stz2r"),  c!("ldr2r"),  c!("str2r"),  c!("lda2r"),  c!("sta2r"),  c!("dei2r"),  c!("deo2r"),
+    c!("add2r"),  c!("sub2r"),  c!("mul2r"),  c!("div2r"),  c!("and2r"),  c!("ora2r"),  c!("eor2r"),  c!("sft2r"),
+    c!("lit"),    c!("inck"),   c!("popk"),   c!("nipk"),   c!("swpk"),   c!("rotk"),   c!("dupk"),   c!("ovrk"),
+    c!("equk"),   c!("neqk"),   c!("gthk"),   c!("lthk"),   c!("jmpk"),   c!("jcnk"),   c!("jsrk"),   c!("sthk"),
+    c!("ldzk"),   c!("stzk"),   c!("ldrk"),   c!("strk"),   c!("ldak"),   c!("stak"),   c!("deik"),   c!("deok"),
+    c!("addk"),   c!("subk"),   c!("mulk"),   c!("divk"),   c!("andk"),   c!("orak"),   c!("eork"),   c!("sftk"),
+    c!("lit2"),   c!("inc2k"),  c!("pop2k"),  c!("nip2k"),  c!("swp2k"),  c!("rot2k"),  c!("dup2k"),  c!("ovr2k"),
+    c!("equ2k"),  c!("neq2k"),  c!("gth2k"),  c!("lth2k"),  c!("jmp2k"),  c!("jcn2k"),  c!("jsr2k"),  c!("sth2k"),
+    c!("ldz2k"),  c!("stz2k"),  c!("ldr2k"),  c!("str2k"),  c!("lda2k"),  c!("sta2k"),  c!("dei2k"),  c!("deo2k"),
+    c!("add2k"),  c!("sub2k"),  c!("mul2k"),  c!("div2k"),  c!("and2k"),  c!("ora2k"),  c!("eor2k"),  c!("sft2k"),
+    c!("litr"),   c!("inckr"),  c!("popkr"),  c!("nipkr"),  c!("swpkr"),  c!("rotkr"),  c!("dupkr"),  c!("ovrkr"),
+    c!("equkr"),  c!("neqkr"),  c!("gthkr"),  c!("lthkr"),  c!("jmpkr"),  c!("jcnkr"),  c!("jsrkr"),  c!("sthkr"),
+    c!("ldzkr"),  c!("stzkr"),  c!("ldrkr"),  c!("strkr"),  c!("ldakr"),  c!("stakr"),  c!("deikr"),  c!("deokr"),
+    c!("addkr"),  c!("subkr"),  c!("mulkr"),  c!("divkr"),  c!("andkr"),  c!("orakr"),  c!("eorkr"),  c!("sftkr"),
+    c!("lit2r"),  c!("inc2kr"), c!("pop2kr"), c!("nip2kr"), c!("swp2kr"), c!("rot2kr"), c!("dup2kr"), c!("ovr2kr"),
+    c!("equ2kr"), c!("neq2kr"), c!("gth2kr"), c!("lth2kr"), c!("jmp2kr"), c!("jcn2kr"), c!("jsr2kr"), c!("sth2kr"),
+    c!("ldz2kr"), c!("stz2kr"), c!("ldr2kr"), c!("str2kr"), c!("lda2kr"), c!("sta2kr"), c!("dei2kr"), c!("deo2kr"),
+    c!("add2kr"), c!("sub2kr"), c!("mul2kr"), c!("div2kr"), c!("and2kr"), c!("ora2kr"), c!("eor2kr"), c!("sft2kr"),
+];
+
+pub unsafe fn find_opcode_by_name(name: *const c_char) -> Option<UxnOp> {
+    let lname = strdup(name);
+    for i in 0..strlen(name) {
+        *(lname.add(i)) = tolower(*(name.add(i)) as c_int) as c_char;
+    }
+    for i in 0..AsmOpNames.len() {
+        let op_name = (*AsmOpNames)[i];
+        if strcmp(op_name, lname) == 0 {
+            free(lname);
+            return Some(core::mem::transmute(i as u8));
+        }
+    }
+    free(lname);
+    return None;
+}
+
+pub unsafe fn has_byte_immediate(op: UxnOp) -> bool {
+    op == UxnOp::LIT
+ || op == UxnOp::LITr
+}
+
+pub unsafe fn has_short_immediate(op: UxnOp) -> bool {
+    op == UxnOp::JCI
+ || op == UxnOp::JSI
+ || op == UxnOp::JMI
+ || op == UxnOp::LIT2
+ || op == UxnOp::LIT2r
+}
+
+pub unsafe fn has_relative_immediate(op: UxnOp) -> bool {
+    op == UxnOp::JCI
+ || op == UxnOp::JSI
+ || op == UxnOp::JMI
+}
+
+pub unsafe fn has_immediate(op: UxnOp) -> bool {
+    has_byte_immediate(op) || has_short_immediate(op)
+}
+
+pub unsafe fn process_asm_statements(output: *mut String_Builder, asm_stmts: *const [AsmStmt], assembler: *mut Assembler) {
+    for i in 0..asm_stmts.len() {
+        let asm_stmt = (*asm_stmts)[i];
+        process_asm_statement(output, asm_stmt, assembler);
+    }
+}
+
+pub unsafe fn process_asm_statement(output: *mut String_Builder, asm_stmt: AsmStmt, assembler: *mut Assembler) {
+    // TODO: leaky function, but beware holding onto strings produced by the lexer
+
+    let mut lexer_name: String_Builder = zeroed();
+    sb_appendf(&mut lexer_name, c!("%s:%d:%d <asm>"), asm_stmt.loc.input_path, asm_stmt.loc.line_number, asm_stmt.loc.line_offset);
+    da_append(&mut lexer_name, 0);
+    let mut l = lexer::new(lexer_name.items, asm_stmt.line, asm_stmt.line.add(strlen(asm_stmt.line)), false);
+    let saved_point = l.parse_point;
+    lexer::get_token(&mut l).expect("Lexing error");
+    match l.token {
+        Token::EOF => { /* Allow empty asm line, not sure if useful */ }
+        Token::ID => {
+            // label or opcode
+            lexer::get_token(&mut l).expect("Lexing error");
+            match l.token {
+                Token::Colon => {
+                    // label
+                    link_label(assembler, get_or_create_label_by_name(assembler, l.string), (*output).count);
+                    lexer::get_token(&mut l).expect("Lexing error");
+                    match l.token {
+                        Token::ID => { /* must be an an opcode */ }
+                        Token::EOF => { return; }
+                        _ => {
+                            diagf!(loc(&mut l), c!("ERROR: expected %s but got %s\n"),
+                                lexer::display_token(Token::ID),
+                                lexer::display_token(l.token));
+                            abort();
+                        }
+                    }
+                }
+                _ => {
+                    l.parse_point = saved_point;
+                    lexer::get_token(&mut l).expect("Lexing error");
+                }
+            }
+        }
+        _ => {
+            diagf!(loc(&mut l), c!("ERROR: expected %s but got %s\n"),
+                lexer::display_token(Token::ID), lexer::display_token(l.token));
+            abort();
+        }
+    }
+    // must be an opcode
+    if let Some(opcode) = find_opcode_by_name(l.string) {
+        write_op(output, opcode);
+        lexer::get_token(&mut l).expect("Lexing error");
+        if has_immediate(opcode) {
+            match l.token {
+                Token::ID => {
+                    // must be a label, only valid for short opcodes
+                    if has_short_immediate(opcode) {
+                        let label = get_or_create_label_by_name(assembler, l.string);
+                        if has_relative_immediate(opcode) {
+                            write_label_rel(output, label, assembler, 0);
+                        } else {
+                            write_label_abs(output, label, assembler, 0);
+                        }
+                    } else {
+                        diagf!(loc(&mut l), c!("ERROR: label is not a valid short immediate\n"));
+                        abort();
+                    }
+                }
+                Token::IntLit | Token::CharLit => {
+                    // immediate number literal
+                    if has_short_immediate(opcode) {
+                        write_short(output, l.int_number as u16);
+                    } else {
+                        write_byte(output, l.int_number as u8);
+                    }
+                }
+                _ => {
+                    diagf!(loc(&mut l), c!("ERROR: expected %s, %s, or %s but got %s\n"),
+                        lexer::display_token(Token::ID),
+                        lexer::display_token(Token::IntLit),
+                        lexer::display_token(Token::CharLit),
+                        lexer::display_token(l.token));
+                    abort();
+                }
+            }
+        } else {
+            match l.token {
+                Token::EOF => { return; }
+                _ => {
+                    diagf!(loc(&mut l), c!("ERROR: expected end of the line but got %s\n"),
+                        lexer::display_token(l.token));
+                    abort();
+                }
+            }
+        }
+    } else {
+        diagf!(loc(&mut l), c!("ERROR: invalid uxn opcode: %s\n"), l.string);
+        abort();
+    }
+    lexer::get_token(&mut l).expect("Lexing error");
+    match l.token {
+        Token::EOF => { return; }
+        _ => {
+            diagf!(loc(&mut l), c!("ERROR: expected nothing but got %s\n"),
+                lexer::display_token(l.token));
+            abort();
+        }
+    }
 }

--- a/tests.json
+++ b/tests.json
@@ -2035,5 +2035,117 @@
         "expected_stdout": "HELO\n",
         "state": "Enabled",
         "comment": ""
+    },
+    {
+        "case": "asm_uxn",
+        "target": "gas-x86_64-windows",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "gas-x86_64-linux",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "gas-x86_64-darwin",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "gas-aarch64-linux",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "gas-aarch64-darwin",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "uxn",
+        "expected_stdout": "BBB\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "asm_uxn",
+        "target": "6502",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_uxn",
+        "target": "ilasm-mono",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "gas-x86_64-windows",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "gas-x86_64-linux",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "gas-x86_64-darwin",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "gas-aarch64-linux",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "gas-aarch64-darwin",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "uxn",
+        "expected_stdout": "69\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "6502",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "asm_func_uxn",
+        "target": "ilasm-mono",
+        "expected_stdout": "",
+        "state": "Disabled",
+        "comment": "Doesn't make sense for this target"
     }
 ]

--- a/tests.json
+++ b/tests.json
@@ -2080,7 +2080,7 @@
     },
     {
         "case": "asm_uxn",
-        "target": "6502",
+        "target": "6502-posix",
         "expected_stdout": "",
         "state": "Disabled",
         "comment": "Doesn't make sense for this target"
@@ -2136,7 +2136,7 @@
     },
     {
         "case": "asm_func_uxn",
-        "target": "6502",
+        "target": "6502-posix",
         "expected_stdout": "",
         "state": "Disabled",
         "comment": "Doesn't make sense for this target"

--- a/tests/asm_func_uxn.b
+++ b/tests/asm_func_uxn.b
@@ -1,0 +1,15 @@
+add __asm__(
+    "lit 0x04",
+    "ldz2",
+    "lit 0x06",
+    "ldz2",
+    "add2",
+    "lit 0x04",
+    "stz2",
+    "jmp2r"
+);
+
+main() {
+    extrn printf;
+    printf("%d\n", add(34, 35));
+}

--- a/tests/asm_uxn.b
+++ b/tests/asm_uxn.b
@@ -1,0 +1,17 @@
+main() {
+    extrn printf, putchar;
+    auto i;
+    i = 0; while (i < 3) {
+        __asm__(
+            "lit 'B'",
+            "lit 0x18",
+            "deo"
+        );
+        i++;
+    }
+    /* asm labels are global and live in a distinct namespace */
+    __asm__("jmi main_skip");
+    printf("Should be skipped\n");
+    __asm__("main_skip:");
+    putchar('\n');
+}


### PR DESCRIPTION
Introduce a simple inline assembly for uxn target. Syntax is custom (compared to uxnasm), but it resembles other "traditional" assembly languages.

Make `uxn::generate_program` return an `Option` so now codegen can fail gracefully (e.g. when encountering an assembly error or an unknown extrn), instead of calling `abort()`.

Move "magic" uxn platform functions from `generate_extrns` to `libb/uxn.b` implemented in that inline asm.

Now that functions like `uxn_deo` live in `libb`, ensure that uxn-specific examples work when compiled with libb (without `-nostdlib` flag).

Make `libb/uxn.b` nicer by using features which were introduced after it was initially written: global initialization, extrn-less out of order func calls.