### PR TITLE
Merge all run_program() functions of codegens into generate_programs()

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -1356,122 +1356,84 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
 
     match target {
         Target::Gas_AArch64_Linux => {
-            if !*nobuild {
-                codegen::gas_aarch64::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_aarch64::run_program(&mut cmd, program_path, da_slice(run_args), Os::Linux)?;
-            }
+            codegen::gas_aarch64::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args), targets::Os::Linux,
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::Gas_AArch64_Darwin => {
-            if !*nobuild {
-                codegen::gas_aarch64::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_aarch64::run_program(&mut cmd, program_path, da_slice(run_args), Os::Darwin)?;
-            }
+            codegen::gas_aarch64::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args), targets::Os::Darwin,
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::Gas_x86_64_Linux => {
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(&mut cmd, program_path, da_slice(run_args), Os::Linux)?
-            }
+            codegen::gas_x86_64::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args), targets::Os::Linux,
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::Gas_x86_64_Windows => {
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Windows, *nostdlib, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(&mut cmd, program_path, da_slice(run_args), Os::Windows)?;
-            }
-        },
+            codegen::gas_x86_64::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args), targets::Os::Windows,
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
+        }
         Target::Gas_x86_64_Darwin => {
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(&mut cmd, program_path, da_slice(run_args), Os::Darwin)?;
-            }
+            codegen::gas_x86_64::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args), targets::Os::Darwin,
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::Uxn => {
-            if !*nobuild {
-                codegen::uxn::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                // TODO: the exact uxn runner (`uxncli` or `uxnemu`) should be customizable via the codegen parameters (-C)
-                // when they are implemented. For now we are hardcoding the runner to be `uxncli` so it passes the CI.
-                // But ideally, for a better first impression purposes (especially when the user tries out examples/uxn/screen.b),
-                // the default runner should be `uxnemu`.
-                codegen::uxn::run_program(&mut cmd, c!("uxncli"), program_path, da_slice(run_args))?;
-            }
+            codegen::uxn::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args),
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::Mos6502_Posix => {
-            let config = codegen::mos6502::parse_config_from_link_flags(da_slice(*linker))?;
-
-            if !*nobuild {
-                codegen::mos6502::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, config, *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::mos6502::run_program(&mut cmd, config, program_path, da_slice(run_args))?;
-            }
+            codegen::mos6502::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args),
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
         Target::ILasm_Mono => {
-            if !*nobuild {
-                codegen::ilasm_mono::generate_program(
-                    // Inputs
-                    &c.program, program_path, garbage_base, da_slice(*linker), *debug,
-                    // Temporaries
-                    &mut output, &mut cmd,
-                )?;
-            }
-
-            if *run {
-                codegen::ilasm_mono::run_program(&mut cmd, program_path, da_slice(run_args))?;
-            }
+            codegen::ilasm_mono::generate_program(
+                // Inputs
+                &c.program, program_path, garbage_base,
+                da_slice(*linker), da_slice(run_args),
+                *nostdlib, *debug, *nobuild, *run,
+                // Temporaries
+                &mut output, &mut cmd,
+            )?;
         }
     }
     Some(())

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -491,136 +491,137 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, linker: *const [*const c_char], os: Os, nostdlib: bool, debug: bool,
+    p: *const Program, program_path: *const c_char, garbage_base: *const c_char,
+    linker: *const [*const c_char], run_args: *const [*const c_char], os: Os,
+    nostdlib: bool, debug: bool, nobuild: bool, run: bool,
     // Temporaries
     output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
-    if debug { todo!("Debug information for aarch64") }
+    if !nobuild {
+        if debug { todo!("Debug information for aarch64") }
 
-    generate_funcs(output, da_slice((*p).funcs), da_slice((*p).variadics), os);
-    generate_asm_funcs(output, da_slice((*p).asm_funcs), os);
-    generate_globals(output, da_slice((*p). globals), os);
-    generate_data_section(output, da_slice((*p).data));
+        generate_funcs(output, da_slice((*p).funcs), da_slice((*p).variadics), os);
+        generate_asm_funcs(output, da_slice((*p).asm_funcs), os);
+        generate_globals(output, da_slice((*p). globals), os);
+        generate_data_section(output, da_slice((*p).data));
 
-    let output_asm_path = temp_sprintf(c!("%s.s"), garbage_base);
-    write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
-    log(Log_Level::INFO, c!("generated %s"), output_asm_path);
+        let output_asm_path = temp_sprintf(c!("%s.s"), garbage_base);
+        write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
+        log(Log_Level::INFO, c!("generated %s"), output_asm_path);
 
-    match os {
-        Os::Linux => {
-            let (gas, cc) = if cfg!(target_arch = "aarch64") && (cfg!(target_os = "linux") || cfg!(target_os = "android")) {
-                (c!("as"), c!("cc"))
-            } else {
-                // TODO: document somewhere the additional packages you may require to cross compile gas-aarch64-linux
-                //   The packages include qemu-user and some variant of the aarch64 gcc compiler (different distros call it differently)
-                (c!("aarch64-linux-gnu-as"), c!("aarch64-linux-gnu-gcc"))
-            };
-
-            let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
-            cmd_append! {
-                cmd,
-                gas, c!("-o"), output_obj_path, output_asm_path,
-            }
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            cmd_append! {
-                cmd,
-                cc, if cfg!(target_os = "android") {
-                    c!("-fPIC")
+        match os {
+            Os::Linux => {
+                let (gas, cc) = if cfg!(target_arch = "aarch64") && (cfg!(target_os = "linux") || cfg!(target_os = "android")) {
+                    (c!("as"), c!("cc"))
                 } else {
-                    c!("-no-pie")
-                },
-                c!("-o"), program_path, output_obj_path,
-            }
-            if nostdlib {
-                cmd_append!(cmd, c!("-nostdlib"));
-            }
-            da_append_many(cmd, linker);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
-        }
-        Os::Darwin => {
-            let (gas, cc) = (c!("as"), c!("cc"));
+                    // TODO: document somewhere the additional packages you may require to cross compile gas-aarch64-linux
+                    //   The packages include qemu-user and some variant of the aarch64 gcc compiler (different distros call it differently)
+                    (c!("aarch64-linux-gnu-as"), c!("aarch64-linux-gnu-gcc"))
+                };
 
-            if !(cfg!(target_os = "macos")) {
-                log(Log_Level::ERROR, c!("Cross-compilation of darwin is not supported"));
-                return None;
-            }
-
-            let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
-            cmd_append! {
-                cmd,
-                gas, c!("-arch"), c!("arm64"), c!("-o"), output_obj_path, output_asm_path,
-            }
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            cmd_append! {
-                cmd,
-                cc, c!("-arch"), c!("arm64"), c!("-o"), program_path, output_obj_path,
-            }
-            if nostdlib {
+                let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
                 cmd_append! {
                     cmd,
-                    c!("-nostdlib"),
+                    gas, c!("-o"), output_obj_path, output_asm_path,
                 }
-            }
-            da_append_many(cmd, linker);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
-        }
-        Os::Windows => todo!(),
-    }
-}
+                if !cmd_run_sync_and_reset(cmd) { return None; }
 
-pub unsafe fn run_program(cmd: *mut Cmd, program_path: *const c_char, run_args: *const [*const c_char], os: Os) -> Option<()> {
-    match os {
-        Os::Linux => {
-            if !(cfg!(target_arch = "aarch64") && cfg!(target_os = "linux")) {
                 cmd_append! {
                     cmd,
-                    c!("qemu-aarch64"), c!("-L"), c!("/usr/aarch64-linux-gnu"),
+                    cc, if cfg!(target_os = "android") {
+                        c!("-fPIC")
+                    } else {
+                        c!("-no-pie")
+                    },
+                    c!("-o"), program_path, output_obj_path,
                 }
+                if nostdlib {
+                    cmd_append!(cmd, c!("-nostdlib"));
+                }
+                da_append_many(cmd, linker);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
             }
+            Os::Darwin => {
+                let (gas, cc) = (c!("as"), c!("cc"));
 
-            // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
-            let run_path: *const c_char;
-            if (strchr(program_path, '/' as c_int)).is_null() {
-                run_path = temp_sprintf(c!("./%s"), program_path);
-            } else {
-                run_path = program_path;
+                if !(cfg!(target_os = "macos")) {
+                    log(Log_Level::ERROR, c!("Cross-compilation of darwin is not supported"));
+                    return None;
+                }
+
+                let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
+                cmd_append! {
+                    cmd,
+                    gas, c!("-arch"), c!("arm64"), c!("-o"), output_obj_path, output_asm_path,
+                }
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+                cmd_append! {
+                    cmd,
+                    cc, c!("-arch"), c!("arm64"), c!("-o"), program_path, output_obj_path,
+                }
+                if nostdlib {
+                    cmd_append! {
+                        cmd,
+                        c!("-nostdlib"),
+                    }
+                }
+                da_append_many(cmd, linker);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
             }
-
-            cmd_append! {
-                cmd,
-                run_path,
-            }
-
-            da_append_many(cmd, run_args);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
+            Os::Windows => todo!(),
         }
-        Os::Darwin => {
-            if !cfg!(target_arch = "aarch64") {
-                log(Log_Level::ERROR, c!("This runner is only for aarch64 Darwin, but the current target is not aarch64 Darwin."));
-                return None;
-            }
-
-            // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Darwin. It has to be `./program`.
-            let run_path: *const c_char;
-            if (strchr(program_path, '/' as c_int)).is_null() {
-                run_path = temp_sprintf(c!("./%s"), program_path);
-            } else {
-                run_path = program_path;
-            }
-
-            cmd_append! {
-                cmd,
-                run_path,
-            }
-
-            da_append_many(cmd, run_args);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
-        }
-        Os::Windows => todo!(),
     }
+
+    if run {
+        match os {
+            Os::Linux => {
+                if !(cfg!(target_arch = "aarch64") && cfg!(target_os = "linux")) {
+                    cmd_append! {
+                        cmd,
+                        c!("qemu-aarch64"), c!("-L"), c!("/usr/aarch64-linux-gnu"),
+                    }
+                }
+
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(program_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), program_path);
+                } else {
+                    run_path = program_path;
+                }
+
+                cmd_append! {
+                    cmd,
+                    run_path,
+                }
+
+                da_append_many(cmd, run_args);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
+            Os::Darwin => {
+                if !cfg!(target_arch = "aarch64") {
+                    log(Log_Level::ERROR, c!("This runner is only for aarch64 Darwin, but the current target is not aarch64 Darwin."));
+                    return None;
+                }
+
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Darwin. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(program_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), program_path);
+                } else {
+                    run_path = program_path;
+                }
+
+                cmd_append! {
+                    cmd,
+                    run_path,
+                }
+
+                da_append_many(cmd, run_args);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
+            Os::Windows => todo!(),
+        }
+    }
+    Some(())
 }

--- a/src/codegen/gas_x86_64.rs
+++ b/src/codegen/gas_x86_64.rs
@@ -368,153 +368,150 @@ pub unsafe fn generate_data_section(output: *mut String_Builder, data: *const [u
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, linker: *const [*const c_char], os: Os, nostdlib: bool, debug: bool,
+    p: *const Program, program_path: *const c_char, garbage_base: *const c_char,
+    linker: *const [*const c_char], run_args: *const [*const c_char], os: Os,
+    nostdlib: bool, debug: bool, nobuild: bool, run: bool,
     // Temporaries
     output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
-    match os {
-        Os::Darwin => sb_appendf(output, c!(".text\n")),
-        Os::Linux | Os::Windows => sb_appendf(output, c!(".section .text\n")),
-    };
-    generate_funcs(output, da_slice((*p).funcs), debug, os);
-    generate_asm_funcs(output, da_slice((*p).asm_funcs), os);
-    match os {
-        Os::Darwin => sb_appendf(output, c!(".data\n")),
-        Os::Linux | Os::Windows => sb_appendf(output, c!(".section .data\n")),
-    };
-    generate_data_section(output, da_slice((*p).data));
-    generate_globals(output, da_slice((*p).globals), os);
+    if !nobuild {
+        match os {
+            Os::Darwin => sb_appendf(output, c!(".text\n")),
+            Os::Linux | Os::Windows => sb_appendf(output, c!(".section .text\n")),
+        };
+        generate_funcs(output, da_slice((*p).funcs), debug, os);
+        generate_asm_funcs(output, da_slice((*p).asm_funcs), os);
+        match os {
+            Os::Darwin => sb_appendf(output, c!(".data\n")),
+            Os::Linux | Os::Windows => sb_appendf(output, c!(".section .data\n")),
+        };
+        generate_data_section(output, da_slice((*p).data));
+        generate_globals(output, da_slice((*p).globals), os);
 
-    let output_asm_path = temp_sprintf(c!("%s.s"), garbage_base);
-    write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
-    log(Log_Level::INFO, c!("generated %s"), output_asm_path);
+        let output_asm_path = temp_sprintf(c!("%s.s"), garbage_base);
+        write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
+        log(Log_Level::INFO, c!("generated %s"), output_asm_path);
 
-    match os {
-        Os::Darwin => {
-            if !(cfg!(target_os = "macos")) {
-                // TODO: think how to approach cross-compilation
-                log(Log_Level::ERROR, c!("Cross-compilation of darwin is not supported"));
-                return None;
-            }
+        match os {
+            Os::Darwin => {
+                if !(cfg!(target_os = "macos")) {
+                    // TODO: think how to approach cross-compilation
+                    log(Log_Level::ERROR, c!("Cross-compilation of darwin is not supported"));
+                    return None;
+                }
 
-            let (gas, cc) = (c!("as"), c!("cc"));
+                let (gas, cc) = (c!("as"), c!("cc"));
 
-            let output_obj_path = temp_sprintf(c!("%s.o"), program_path);
-            cmd_append! {
-                cmd,
-                gas, c!("-arch"), c!("x86_64"), c!("-o"), output_obj_path, output_asm_path,
-            }
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            cmd_append! {
-                cmd,
-                cc, c!("-arch"), c!("x86_64"), c!("-o"), program_path, output_obj_path,
-            }
-            if nostdlib {
-                cmd_append!(cmd, c!("-nostdlib"));
-            }
-            da_append_many(cmd, linker);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            Some(())
-        }
-        Os::Linux => {
-            if !(cfg!(target_arch = "x86_64") && cfg!(target_os = "linux")) {
-                // TODO: think how to approach cross-compilation
-                log(Log_Level::ERROR, c!("Cross-compilation of x86_64 linux is not supported for now"));
-                return None;
-            }
-
-            let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
-            cmd_append! {
-                cmd,
-                c!("as"), output_asm_path, c!("-o"), output_obj_path,
-            }
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            cmd_append! {
-                cmd,
-                c!("cc"), c!("-no-pie"), c!("-o"), program_path, output_obj_path,
-            }
-            if nostdlib {
-                cmd_append!(cmd, c!("-nostdlib"));
-            }
-            da_append_many(cmd, linker);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            Some(())
-        }
-        Os::Windows => {
-            let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
-            cmd_append! {
-                cmd,
-                c!("as"), output_asm_path, c!("-o"), output_obj_path,
-            }
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            cmd_append! {
-                cmd,
-                c!("x86_64-w64-mingw32-gcc"), c!("-no-pie"), c!("-o"), program_path, output_obj_path,
-            }
-            if nostdlib {
-                cmd_append!(cmd, c!("-nostdlib"));
-            }
-            da_append_many(cmd, linker);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-
-            Some(())
-        }
-    }
-}
-
-pub unsafe fn run_program(cmd: *mut Cmd, program_path: *const c_char, run_args: *const [*const c_char], os: Os) -> Option<()> {
-    match os {
-        Os::Linux => {
-            // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
-            let run_path: *const c_char;
-            if (strchr(program_path, '/' as c_int)).is_null() {
-                run_path = temp_sprintf(c!("./%s"), program_path);
-            } else {
-                run_path = program_path;
-            }
-
-            cmd_append! {cmd, run_path}
-            da_append_many(cmd, run_args);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
-        }
-        Os::Windows => {
-            // TODO: document that you may need wine as a system package to cross-run gas-x86_64-windows
-            if !cfg!(target_os = "windows") {
+                let output_obj_path = temp_sprintf(c!("%s.o"), program_path);
                 cmd_append! {
                     cmd,
-                    c!("wine"),
+                    gas, c!("-arch"), c!("x86_64"), c!("-o"), output_obj_path, output_asm_path,
                 }
-            }
+                if !cmd_run_sync_and_reset(cmd) { return None; }
 
-            cmd_append! {cmd, program_path}
-            da_append_many(cmd, run_args);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
-        }
-        Os::Darwin => {
-            if !cfg!(target_os = "macos") {
-                log(Log_Level::ERROR, c!("This runner is only for macOS, but the current target is not macOS."));
-                return None;
+                cmd_append! {
+                    cmd,
+                    cc, c!("-arch"), c!("x86_64"), c!("-o"), program_path, output_obj_path,
+                }
+                if nostdlib {
+                    cmd_append!(cmd, c!("-nostdlib"));
+                }
+                da_append_many(cmd, linker);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
             }
+            Os::Linux => {
+                if !(cfg!(target_arch = "x86_64") && cfg!(target_os = "linux")) {
+                    // TODO: think how to approach cross-compilation
+                    log(Log_Level::ERROR, c!("Cross-compilation of x86_64 linux is not supported for now"));
+                    return None;
+                }
 
-            // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Darwin. It has to be `./program`.
-            let run_path: *const c_char;
-            if (strchr(program_path, '/' as c_int)).is_null() {
-                run_path = temp_sprintf(c!("./%s"), program_path);
-            } else {
-                run_path = program_path;
+                let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
+                cmd_append! {
+                    cmd,
+                    c!("as"), output_asm_path, c!("-o"), output_obj_path,
+                }
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+
+                cmd_append! {
+                    cmd,
+                    c!("cc"), c!("-no-pie"), c!("-o"), program_path, output_obj_path,
+                }
+                if nostdlib {
+                    cmd_append!(cmd, c!("-nostdlib"));
+                }
+                da_append_many(cmd, linker);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
             }
+            Os::Windows => {
+                let output_obj_path = temp_sprintf(c!("%s.o"), garbage_base);
+                cmd_append! {
+                    cmd,
+                    c!("as"), output_asm_path, c!("-o"), output_obj_path,
+                }
+                if !cmd_run_sync_and_reset(cmd) { return None; }
 
-            cmd_append! {cmd, run_path}
-            da_append_many(cmd, run_args);
-            if !cmd_run_sync_and_reset(cmd) { return None; }
-            Some(())
+                cmd_append! {
+                    cmd,
+                    c!("x86_64-w64-mingw32-gcc"), c!("-no-pie"), c!("-o"), program_path, output_obj_path,
+                }
+                if nostdlib {
+                    cmd_append!(cmd, c!("-nostdlib"));
+                }
+                da_append_many(cmd, linker);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
         }
     }
+
+    if run {
+        match os {
+            Os::Linux => {
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(program_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), program_path);
+                } else {
+                    run_path = program_path;
+                }
+
+                cmd_append! {cmd, run_path}
+                da_append_many(cmd, run_args);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
+            Os::Windows => {
+                // TODO: document that you may need wine as a system package to cross-run gas-x86_64-windows
+                if !cfg!(target_os = "windows") {
+                    cmd_append! {
+                        cmd,
+                        c!("wine"),
+                    }
+                }
+
+                cmd_append! {cmd, program_path}
+                da_append_many(cmd, run_args);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
+            Os::Darwin => {
+                if !cfg!(target_os = "macos") {
+                    log(Log_Level::ERROR, c!("This runner is only for macOS, but the current target is not macOS."));
+                    return None;
+                }
+
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Darwin. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(program_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), program_path);
+                } else {
+                    run_path = program_path;
+                }
+
+                cmd_append! {cmd, run_path}
+                da_append_many(cmd, run_args);
+                if !cmd_run_sync_and_reset(cmd) { return None; }
+            }
+        }
+    }
+
+    Some(())
 }

--- a/src/codegen/ilasm_mono.rs
+++ b/src/codegen/ilasm_mono.rs
@@ -176,46 +176,49 @@ pub unsafe fn generate_funcs(funcs: *const [Func], output: *mut String_Builder, 
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, _linker: *const [*const c_char], debug: bool,
+    p: *const Program, program_path: *const c_char, garbage_base: *const c_char,
+    _linker: *const [*const c_char], run_args: *const [*const c_char],
+    _nostdlib: bool, debug: bool, nobuild: bool, run: bool,
     // Temporaries
     output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
-    if debug { todo!("Debug information for ilasm-mono") }
+    if !nobuild {
+        if debug { todo!("Debug information for ilasm-mono") }
 
-    sb_appendf(output, c!(".assembly 'Main' {}\n"));
-    sb_appendf(output, c!(".module Main.exe\n"));
-    sb_appendf(output, c!(".class Program extends [mscorlib]System.Object {\n"));
-    generate_funcs(da_slice((*p).funcs), output, da_slice((*p).data));
-    sb_appendf(output, c!("    .method static void Main (string[] args) {\n"));
-    sb_appendf(output, c!("        .entrypoint\n"));
-    sb_appendf(output, c!("        call int64 class Program::main()\n"));
-    sb_appendf(output, c!("        pop\n"));
-    sb_appendf(output, c!("        ret\n"));
-    sb_appendf(output, c!("    }\n"));
-    sb_appendf(output, c!("}\n"));
+        sb_appendf(output, c!(".assembly 'Main' {}\n"));
+        sb_appendf(output, c!(".module Main.exe\n"));
+        sb_appendf(output, c!(".class Program extends [mscorlib]System.Object {\n"));
+        generate_funcs(da_slice((*p).funcs), output, da_slice((*p).data));
+        sb_appendf(output, c!("    .method static void Main (string[] args) {\n"));
+        sb_appendf(output, c!("        .entrypoint\n"));
+        sb_appendf(output, c!("        call int64 class Program::main()\n"));
+        sb_appendf(output, c!("        pop\n"));
+        sb_appendf(output, c!("        ret\n"));
+        sb_appendf(output, c!("    }\n"));
+        sb_appendf(output, c!("}\n"));
 
-    let output_asm_path = temp_sprintf(c!("%s.il"), garbage_base);
-    write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
-    log(Log_Level::INFO, c!("generated %s"), output_asm_path);
+        let output_asm_path = temp_sprintf(c!("%s.il"), garbage_base);
+        write_entire_file(output_asm_path, (*output).items as *const c_void, (*output).count)?;
+        log(Log_Level::INFO, c!("generated %s"), output_asm_path);
 
-    cmd_append!{
-        cmd,
-        c!("ilasm"), output_asm_path, temp_sprintf(c!("/output:%s"), program_path)
+        cmd_append!{
+            cmd,
+            c!("ilasm"), output_asm_path, temp_sprintf(c!("/output:%s"), program_path)
+        }
+
+        if !cmd_run_sync_and_reset(cmd) { return None; }
     }
 
-    if !cmd_run_sync_and_reset(cmd) { return None; }
+    if run {
+        cmd_append!{
+            cmd,
+            c!("mono"), program_path,
+        }
 
-    Some(())
-}
-
-pub unsafe fn run_program(cmd: *mut Cmd, program_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
-    cmd_append!{
-        cmd,
-        c!("mono"), program_path,
+        da_append_many(cmd, run_args);
+        if !cmd_run_sync_and_reset(cmd) { return None; }
     }
 
-    da_append_many(cmd, run_args);
-    if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
 }
 

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -1459,29 +1459,48 @@ pub unsafe fn generate_asm_funcs(out: *mut String_Builder, asm_funcs: *const [As
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, config: Config, debug: bool,
+    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char,
+    linker: *const [*const c_char], run_args: *const [*const c_char],
+    _nostdlib: bool, debug: bool, nobuild: bool, run: bool,
     // Temporaries
-    out: *mut String_Builder, _cmd: *mut Cmd,
+    out: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
-    if debug { todo!("Debug information for 6502") }
+    let config = parse_config_from_link_flags(linker)?;
 
-    let mut asm: Assembler = zeroed();
-    generate_entry(out, &mut asm);
-    asm.code_start = config.load_offset;
+    if !nobuild {
+        if debug { todo!("Debug information for 6502") }
 
-    generate_funcs(out, da_slice((*p).funcs), &mut asm);
-    generate_asm_funcs(out, da_slice((*p).asm_funcs), &mut asm);
-    generate_extrns(out, da_slice((*p).extrns), da_slice((*p).funcs), da_slice((*p).globals), da_slice((*p).asm_funcs), &mut asm);
+        let mut asm: Assembler = zeroed();
+        generate_entry(out, &mut asm);
+        asm.code_start = config.load_offset;
 
-    let data_start = config.load_offset + (*out).count as u16;
-    generate_data_section(out, da_slice((*p).data));
-    generate_globals(out, da_slice((*p).globals), &mut asm);
+        generate_funcs(out, da_slice((*p).funcs), &mut asm);
+        generate_asm_funcs(out, da_slice((*p).asm_funcs), &mut asm);
+        generate_extrns(out, da_slice((*p).extrns), da_slice((*p).funcs), da_slice((*p).globals), da_slice((*p).asm_funcs), &mut asm);
 
-    log(Log_Level::INFO, c!("Generated size: 0x%x"), (*out).count as c_uint);
-    apply_relocations(out, data_start, &mut asm);
+        let data_start = config.load_offset + (*out).count as u16;
+        generate_data_section(out, da_slice((*p).data));
+        generate_globals(out, da_slice((*p).globals), &mut asm);
 
-    write_entire_file(program_path, (*out).items as *const c_void, (*out).count)?;
-    log(Log_Level::INFO, c!("generated %s"), program_path);
+        log(Log_Level::INFO, c!("Generated size: 0x%x"), (*out).count as c_uint);
+        apply_relocations(out, data_start, &mut asm);
+
+        write_entire_file(program_path, (*out).items as *const c_void, (*out).count)?;
+        log(Log_Level::INFO, c!("generated %s"), program_path);
+    }
+
+    if run {
+        cmd_append!{
+            cmd,
+            c!("posix6502"), c!("-load-offset"), temp_sprintf(c!("%u"), config.load_offset as c_uint),
+            program_path
+        }
+        if run_args.len() > 0 {
+            cmd_append!(cmd, c!("--"));
+            da_append_many(cmd, run_args);
+        }
+        if !cmd_run_sync_and_reset(cmd) { return None; }
+    }
 
     Some(())
 }
@@ -1491,18 +1510,4 @@ pub const DEFAULT_LOAD_OFFSET: u16 = 0x8000;
 #[derive(Clone, Copy)]
 pub struct Config {
     pub load_offset: u16,
-}
-
-pub unsafe fn run_program(cmd: *mut Cmd, config: Config, program_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
-    cmd_append!{
-        cmd,
-        c!("posix6502"), c!("-load-offset"), temp_sprintf(c!("%u"), config.load_offset as c_uint),
-        program_path
-    }
-    if run_args.len() > 0 {
-        cmd_append!(cmd, c!("--"));
-        da_append_many(cmd, run_args);
-    }
-    if !cmd_run_sync_and_reset(cmd) { return None; }
-    Some(())
 }

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -112,54 +112,61 @@ pub unsafe fn generate_asm_funcs(_output: *mut String_Builder, asm_funcs: *const
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, _linker: *const [*const c_char], debug: bool,
+    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char,
+    _linker: *const [*const c_char], run_args: *const [*const c_char],
+    _nostdlib: bool, debug: bool, nobuild: bool, run: bool,
     // Temporaries
-    output: *mut String_Builder, _cmd: *mut Cmd,
+    output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
-    if debug { todo!("Debug information for uxn") }
+    if !nobuild {
+        if debug { todo!("Debug information for uxn") }
 
-    let mut assembler: Assembler = zeroed();
-    assembler.data_section_label = create_label(&mut assembler);
-    // set the top of the stack
-    write_lit2(output, 0xffff);
-    write_lit_stz2(output, SP);
-    // call main or _start, _start having a priority
-    let mut main_proc = c!("main");
-    for i in 0..(*p).funcs.count {
-        let name = (*(*p).funcs.items.add(i)).name;
-        if strcmp(name, c!("_start")) == 0 {
-            main_proc = c!("_start");
-            break;
+        let mut assembler: Assembler = zeroed();
+        assembler.data_section_label = create_label(&mut assembler);
+        // set the top of the stack
+        write_lit2(output, 0xffff);
+        write_lit_stz2(output, SP);
+        // call main or _start, _start having a priority
+        let mut main_proc = c!("main");
+        for i in 0..(*p).funcs.count {
+            let name = (*(*p).funcs.items.add(i)).name;
+            if strcmp(name, c!("_start")) == 0 {
+                main_proc = c!("_start");
+                break;
+            }
         }
+        write_op(output, UxnOp::JSI);
+        write_label_rel(output, get_or_create_label_by_name(&mut assembler, main_proc), &mut assembler, 0);
+        // break out of the vector we were returned from
+        // also put this as the return address for the next vector which might be called
+        let vector_return_label = create_label(&mut assembler);
+        link_label(&mut assembler, vector_return_label, (*output).count);
+        write_op(output, UxnOp::LIT2r);
+        write_label_abs(output, vector_return_label, &mut assembler, 0);
+        write_op(output, UxnOp::BRK);
+
+        generate_funcs(output, da_slice((*p).funcs), &mut assembler);
+        generate_asm_funcs(output, da_slice((*p).asm_funcs));
+        generate_extrns(output, da_slice((*p).extrns), da_slice((*p).funcs), da_slice((*p).globals), &mut assembler);
+        generate_data_section(output, da_slice((*p).data), &mut assembler);
+        generate_globals(output, da_slice((*p).globals), &mut assembler);
+
+        apply_patches(output, &mut assembler);
+
+        write_entire_file(program_path, (*output).items as *const c_void, (*output).count)?;
+        log(Log_Level::INFO, c!("generated %s\n"), program_path);
     }
-    write_op(output, UxnOp::JSI);
-    write_label_rel(output, get_or_create_label_by_name(&mut assembler, main_proc), &mut assembler, 0);
-    // break out of the vector we were returned from
-    // also put this as the return address for the next vector which might be called
-    let vector_return_label = create_label(&mut assembler);
-    link_label(&mut assembler, vector_return_label, (*output).count);
-    write_op(output, UxnOp::LIT2r);
-    write_label_abs(output, vector_return_label, &mut assembler, 0);
-    write_op(output, UxnOp::BRK);
 
-    generate_funcs(output, da_slice((*p).funcs), &mut assembler);
-    generate_asm_funcs(output, da_slice((*p).asm_funcs));
-    generate_extrns(output, da_slice((*p).extrns), da_slice((*p).funcs), da_slice((*p).globals), &mut assembler);
-    generate_data_section(output, da_slice((*p).data), &mut assembler);
-    generate_globals(output, da_slice((*p).globals), &mut assembler);
+    if run {
+        // TODO: the exact uxn runner (`uxncli` or `uxnemu`) should be customizable via the codegen parameters (-C)
+        // when they are implemented. For now we are hardcoding the runner to be `uxncli` so it passes the CI.
+        // But ideally, for a better first impression purposes (especially when the user tries out examples/uxn/screen.b),
+        // the default runner should be `uxnemu`.
+        cmd_append! {cmd, c!("uxncli"), program_path}
+        da_append_many(cmd, run_args);
+        if !cmd_run_sync_and_reset(cmd) { return None; }
+    }
 
-    apply_patches(output, &mut assembler);
-
-    write_entire_file(program_path, (*output).items as *const c_void, (*output).count)?;
-    log(Log_Level::INFO, c!("generated %s\n"), program_path);
-
-    Some(())
-}
-
-pub unsafe fn run_program(cmd: *mut Cmd, emu: *const c_char, program_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
-    cmd_append! {cmd, emu, program_path}
-    da_append_many(cmd, run_args);
-    if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
 }
 


### PR DESCRIPTION
This dramatically reduces the surface area between the compiler and the codegens which is important for further decoupling of them.