### PR TITLE
Add hashtable and string interning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CRUST_FLAGS=-g --edition 2021 -C opt-level=0 -C panic="abort"
 
 RSS=\
 	$(SRC)/arena.rs \
+	$(SRC)/hashtable.rs \
 	$(SRC)/b.rs \
 	$(SRC)/ir.rs \
 	$(SRC)/crust.rs \

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -1,8 +1,9 @@
 use core::ffi::*;
 use core::mem::zeroed;
+use crate::crust::Str;
+use crate::hashtable::HashTable;
 use crate::nob::*;
 use crate::crust::libc::*;
-use crate::crust::assoc_lookup_cstr;
 use crate::ir::*;
 use crate::lexer::*;
 use crate::missingf;
@@ -127,7 +128,7 @@ pub unsafe fn load_arg_to_reg(arg: Arg, reg: *const c_char, output: *mut String_
     };
 }
 
-pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_count: usize, auto_vars_count: usize, os: Os, variadics: *const [(*const c_char, Variadic)], body: *const [OpWithLocation], output: *mut String_Builder) {
+pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_count: usize, auto_vars_count: usize, os: Os, variadics: *const HashTable<Str, Variadic>, body: *const [OpWithLocation], output: *mut String_Builder) {
     let stack_size = align_bytes(auto_vars_count*8, 16);
     match os {
         Os::Linux => {
@@ -316,7 +317,7 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
                 let mut fixed_args = 0;
                 match fun {
                     Arg::External(name) | Arg::RefExternal(name) => {
-                        if let Some(variadic) = assoc_lookup_cstr(variadics, name) {
+                        if let Some(variadic) = HashTable::get(variadics, Str(name)) {
                             fixed_args = (*variadic).fixed_args;
                         }
                     }
@@ -395,7 +396,7 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
     sb_appendf(output, c!("    ret\n"));
 }
 
-pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], variadics: *const [(*const c_char, Variadic)], os: Os) {
+pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], variadics: *const HashTable<Str, Variadic>, os: Os) {
     sb_appendf(output, c!(".text\n"));
     for i in 0..funcs.len() {
         generate_function((*funcs)[i].name, (*funcs)[i].name_loc, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, os, variadics, da_slice((*funcs)[i].body), output);
@@ -544,7 +545,7 @@ pub unsafe fn generate_program(
 
     if debug { todo!("Debug information for aarch64") }
 
-    generate_funcs(output, da_slice((*program).funcs), da_slice((*program).variadics), os);
+    generate_funcs(output, da_slice((*program).funcs), &(*program).variadics, os);
     generate_asm_funcs(output, da_slice((*program).asm_funcs), os);
     generate_globals(output, da_slice((*program). globals), os);
     generate_data_section(output, da_slice((*program).data));

--- a/src/hashtable.rs
+++ b/src/hashtable.rs
@@ -1,0 +1,220 @@
+use crate::crust::libc;
+use core::hash::{BuildHasher, Hash, Hasher};
+use core::{cmp, mem, ptr};
+
+#[derive(Clone, Copy)]
+pub struct HashTable<K, V, S = DefaultHasher> {
+    pub entries: *mut Entry<K, V>,
+    pub capacity: usize,
+    pub count: usize,
+    pub occupied: *mut u8,
+    pub hasher_builder: S,
+}
+
+#[derive(Clone, Copy)]
+pub struct Entry<K, V> {
+    pub key: K,
+    pub value: V,
+}
+
+#[derive(Clone, Copy)]
+pub enum HtEntry<K, V> {
+    Occupied(*mut Entry<K, V>),
+    Vacant(*mut Entry<K, V>),
+}
+
+impl<K, V, S, H> HashTable<K, V, S>
+where
+    K: Clone + Copy + Hash + Eq,
+    V: Clone + Copy,
+    S: BuildHasher<Hasher = H>,
+    H: Hasher,
+{
+    // Must be power of 2 and greater than or equal to 8
+    pub const MIN_CAPACITY: usize = 8;
+
+    /// Returns previous value stored by this `key` or `None`
+    pub unsafe fn insert(ht: *mut Self, key: K, value: V) -> Option<V> {
+        match Self::find(ht, key) {
+            HtEntry::Occupied(entry) => Some(mem::replace(&mut (*entry).value, value)),
+            HtEntry::Vacant(entry) => {
+                Self::insert_new_key(ht, entry, key, value);
+                None
+            }
+        }
+    }
+
+    pub unsafe fn get(ht: *const Self, key: K) -> Option<*const V> {
+        match Self::find(ht, key) {
+            HtEntry::Occupied(entry) => Some(&(*entry).value),
+            HtEntry::Vacant(_) => None,
+        }
+    }
+
+    pub unsafe fn get_mut(ht: *mut Self, key: K) -> Option<*mut V> {
+        match Self::find(ht, key) {
+            HtEntry::Occupied(entry) => Some(&mut (*entry).value),
+            HtEntry::Vacant(_) => None,
+        }
+    }
+
+    pub unsafe fn find(ht: *const Self, key: K) -> HtEntry<K, V> {
+        if (*ht).capacity == 0 {
+            return HtEntry::Vacant(ptr::null_mut());
+        }
+        
+        let hash = Self::hash_key(ht, key);
+        let mut index = Self::index_from_hash(hash, (*ht).capacity);
+
+        let mut step = 1;
+        loop {
+            let entry = (*ht).entries.add(index);
+            if Self::is_occupied(ht, index) {
+                if (*entry).key == key {
+                    return HtEntry::Occupied(entry);
+                }
+            } else {
+                return HtEntry::Vacant(entry);
+            }
+
+            index = (index + step) & ((*ht).capacity - 1);
+            step += 1;
+        }
+    }
+
+    pub unsafe fn insert_new_key(ht: *mut Self, entry: *mut Entry<K, V>, key: K, value: V) {
+        if entry.is_null() {
+            Self::realloc_rehash(ht);
+
+            // Executes only when capacity was 0 
+            let hash = Self::hash_key(ht, key);
+            let index = Self::index_from_hash(hash, (*ht).capacity);
+            *(*ht).entries.add(index) = Entry { key, value };
+            (*ht).count += 1;
+        } else {
+            (*entry).key = key;
+            (*entry).value = value;
+            (*ht).count += 1;
+
+            // When load factor > 0.75
+            if (3 * (*ht).capacity) / 4 < (*ht).count {
+                Self::realloc_rehash(ht);
+            }
+        }
+    }
+
+    pub unsafe fn realloc_rehash(ht: *mut Self) {
+        let new_capacity = cmp::max((*ht).capacity << 1, Self::MIN_CAPACITY);
+        debug_assert!(new_capacity.is_power_of_two());
+
+        // We need new allocations here, to properly copy entries
+        let new_entries: *mut Entry<K, V> = libc::realloc_items(ptr::null_mut(), new_capacity);
+        let new_occupied: *mut u8 = libc::realloc_items(ptr::null_mut(), new_capacity >> 3);
+        debug_assert!(!new_entries.is_null());
+        debug_assert!(!new_occupied.is_null());
+
+        // Fill occupied with zeros
+        ptr::write_bytes(new_occupied, 0, new_capacity >> 3);
+
+        // Rehash all occupoed entries
+        let buckets_count = (*ht).capacity >> 3;
+        for i in 0..buckets_count {
+            let bucket = *(*ht).occupied.add(i);
+            for j in 0..8 {
+                if (bucket >> j) & 1 == 1 {
+                    let index = (i << 3) + (7 - j);
+                    let entry = *(*ht).entries.add(index);
+                    let hash = Self::hash_key(ht, entry.key);
+                    let new_index = Self::index_from_hash(hash, new_capacity);
+                    let new_bucket = new_index >> 3;
+
+                    *new_entries.add(new_index) = entry;
+                    *new_occupied.add(new_bucket) |= 1 << (7 - (new_index & 7));
+                }
+            }
+        }
+
+        // free old allocations
+        libc::free((*ht).entries);
+        libc::free((*ht).occupied);
+
+        (*ht).capacity = new_capacity;
+        (*ht).entries = new_entries;
+        (*ht).occupied = new_occupied;
+    }
+
+    pub unsafe fn is_occupied(ht: *const Self, index: usize) -> bool {
+        let bucket = *(*ht).occupied.add(index >> 3);
+        let sub_index = 7 - (index & 7);
+        (bucket >> sub_index) & 1 == 1
+    }
+
+    pub unsafe fn index_from_hash(hash: u64, capacity: usize) -> usize {
+        (hash & (capacity as u64 - 1)) as usize
+    }
+
+    pub unsafe fn hash_key(ht: *const Self, key: K) -> u64 {
+        let mut hasher = (*ht).hasher_builder.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct DefaultHasher;
+
+impl BuildHasher for DefaultHasher {
+    type Hasher = Fnv1aHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        Fnv1aHasher { hash: Fnv1aHasher::OFFSET } 
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Fnv1aHasher {
+    pub hash: u64,
+}
+
+impl Fnv1aHasher {
+    const OFFSET: u64 = 14695981039346656037;
+    const PRIME: u64 = 1099511628211;
+}
+
+impl Hasher for Fnv1aHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.hash ^= *byte as u64;
+            self.hash = self.hash.wrapping_mul(Self::PRIME);
+        }
+    }
+
+    fn write_u8(&mut self, i: u8) {
+        self.hash ^= i as u64;
+        self.hash = self.hash.wrapping_mul(Self::PRIME);
+    }
+
+    fn write_u16(&mut self, i: u16) {
+        self.hash ^= i as u64;
+        self.hash = self.hash.wrapping_mul(Self::PRIME);
+    }
+
+    fn write_u32(&mut self, i: u32) {
+        self.hash ^= i as u64;
+        self.hash = self.hash.wrapping_mul(Self::PRIME);
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.hash ^= i;
+        self.hash = self.hash.wrapping_mul(Self::PRIME);
+    }
+
+    fn write_usize(&mut self, i: usize) {
+        self.hash ^= i as u64;
+        self.hash = self.hash.wrapping_mul(Self::PRIME);
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,4 +1,6 @@
 use core::ffi::*;
+use crate::crust::Str;
+use crate::hashtable::HashTable;
 use crate::lexer::*;
 use crate::nob::*;
 
@@ -120,7 +122,7 @@ pub struct Program {
     pub funcs: Array<Func>,
     pub data: Array<u8>,
     pub extrns: Array<*const c_char>,
-    pub variadics: Array<(*const c_char, Variadic)>,
+    pub variadics: HashTable<Str, Variadic>,
     pub globals: Array<Global>,
     pub asm_funcs: Array<AsmFunc>,
 }


### PR DESCRIPTION
Current `HashTable` implementation is very simple and may contain bugs.
There is no `remove` method, but compiler doesn't use it anyway. 
Also how to intern `data section` strings is TBD.