### PR TITLE
Target as a Structure of Function Pointers

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -34,6 +34,7 @@ pub mod arena;
 pub mod codegen;
 pub mod lexer;
 pub mod targets;
+pub mod params;
 pub mod ir;
 pub mod time;
 pub mod shlex;
@@ -52,8 +53,8 @@ use targets::*;
 use lexer::{Lexer, Loc, Token};
 use ir::*;
 use time::Instant;
-use codegen::*;
 use shlex::*;
+use params::*;
 
 pub unsafe fn expect_tokens(l: *mut Lexer, tokens: *const [Token]) -> Option<()> {
     for i in 0..tokens.len() {
@@ -926,7 +927,6 @@ pub struct Compiler {
     /// need to reset the state of the Compiler, just reset all its
     /// Dynamic Arrays and this Arena.
     pub arena: Arena,
-    pub target: Target,
     pub error_count: usize,
     pub historical: bool,
 }
@@ -1180,32 +1180,34 @@ pub unsafe fn get_garbage_base(path: *const c_char, target: Target) -> Option<*m
         write_entire_file(gitignore_path, c!("*") as *const c_void, 1)?;
     }
 
-    Some(temp_sprintf(c!("%s/%s.%s"), garbage_dir, filename, target.name()))
+    Some(temp_sprintf(c!("%s/%s.%s"), garbage_dir, filename, target.api.name))
 }
 
-pub unsafe fn print_available_targets() {
+pub unsafe fn print_available_targets(targets: *const [Target]) {
     fprintf(stderr(), c!("Compilation targets:\n"));
-    for i in 0..TARGET_ORDER.len() {
-        fprintf(stderr(), c!("    %s\n"), (*TARGET_ORDER)[i].name());
+    for i in 0..targets.len() {
+        fprintf(stderr(), c!("    %s\n"), (*targets)[i].api.name);
     }
 }
 
 pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
+    let targets = codegen::load_targets()?;
+
     let default_target;
     if cfg!(target_arch = "aarch64") && (cfg!(target_os = "linux") || cfg!(target_os = "android")) {
-        default_target = Some(Target::Gas_AArch64_Linux);
+        default_target = Some(Target::by_name(da_slice(targets), c!("gas-aarch64-linux")).expect("Default target for Linux on AArch64"));
     } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
-        default_target = Some(Target::Gas_AArch64_Darwin);
+        default_target = Some(Target::by_name(da_slice(targets), c!("gas-aarch64-darwin")).expect("Default target for Darwin on AArch64"));
     } else if cfg!(target_arch = "x86_64") && cfg!(target_os = "linux") {
-        default_target = Some(Target::Gas_x86_64_Linux);
+        default_target = Some(Target::by_name(da_slice(targets), c!("gas-x86_64-linux")).expect("Default target for Linux on x86_64"));
     } else if cfg!(target_arch = "x86_64") && cfg!(target_os = "windows") {
-        default_target = Some(Target::Gas_x86_64_Windows);
+        default_target = Some(Target::by_name(da_slice(targets), c!("gas-x86_64-windows")).expect("Default target for Windows on x86_64"));
     } else {
         default_target = None;
     }
 
     let default_target_name = if let Some(default_target) = default_target {
-        default_target.name()
+        default_target.api.name
     } else {
         ptr::null()
     };
@@ -1215,10 +1217,10 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     let run         = flag_bool(c!("run"), false, c!("Run the compiled program (if applicable for the target)"));
     let nobuild  = flag_bool(c!("nobuild"), false, temp_sprintf(c!("Skip the build step. Useful in conjunction with the -%s flag when you already have a built program and just want to run it on the specified target without rebuilding it."), flag_name(run)));
     let help        = flag_bool(c!("help"), false, c!("Print this help message"));
-    let codegen_args = flag_list(CODEGEN_FLAG_NAME, temp_sprintf(c!("Pass an argument to the codegen of the current target selected by the -%s flag. Pass argument `-%s help` to learn more about what current codegen provides. All sorts of linker flag parameters are probably there."), flag_name(target_name), CODEGEN_FLAG_NAME));
+    let codegen_args = flag_list(PARAM_FLAG_NAME, temp_sprintf(c!("Pass an argument to the codegen of the current target selected by the -%s flag. Pass argument `-%s help` to learn more about what current codegen provides. All sorts of linker flag parameters are probably there."), flag_name(target_name), PARAM_FLAG_NAME));
     let linker = {
         let name = c!("L");
-        flag_list(name, temp_sprintf(c!("DEPRECATED! Append a flag to the linker of the target platform. But not every target even has a linker! For backward compatibility we transform `-%s foo -%s bar -%s ...` into `-%s link-args='foo bar ...'` but do not expect every codegen to support that. Use `-%s help` to learn more about what your current codegen supports. Expect -%s to be removed entirely in the future."), name, name, name, CODEGEN_FLAG_NAME, CODEGEN_FLAG_NAME, name))
+        flag_list(name, temp_sprintf(c!("DEPRECATED! Append a flag to the linker of the target platform. But not every target even has a linker! For backward compatibility we transform `-%s foo -%s bar -%s ...` into `-%s link-args='foo bar ...'` but do not expect every codegen to support that. Use `-%s help` to learn more about what your current codegen supports. Expect -%s to be removed entirely in the future."), name, name, name, PARAM_FLAG_NAME, PARAM_FLAG_NAME, name))
     };
     let nostdlib    = flag_bool(c!("nostdlib"), false, c!("Do not link with standard libraries like libb and/or libc on some platforms"));
     let ir          = flag_bool(c!("ir"), false, c!("Instead of compiling, dump the IR of the program to stdout"));
@@ -1262,19 +1264,18 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     }
 
     if strcmp(*target_name, c!("list")) == 0 {
-        print_available_targets();
+        print_available_targets(da_slice(targets));
         return Some(());
     }
 
-    let Some(target) = Target::by_name(*target_name) else {
+    let Some(target) = Target::by_name(da_slice(targets), *target_name) else {
         usage();
-        print_available_targets();
+        print_available_targets(da_slice(targets));
         log(Log_Level::ERROR, c!("Unknown target `%s`"), *target_name);
         return None;
     };
 
     let mut c: Compiler = zeroed();
-    c.target = target;
     c.historical = *historical;
 
     if (*linker).count > 0 {
@@ -1285,19 +1286,10 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         let codegen_arg = temp_sprintf(c!("link-args=%s"), shlex_join(&mut s));
         da_append(codegen_args, codegen_arg);
         shlex_free(&mut s);
-        log(Log_Level::WARNING, c!("Flag -%s is DEPRECATED! Interpreting it as `-%s %s` instead."), flag_name(linker), CODEGEN_FLAG_NAME, codegen_arg);
+        log(Log_Level::WARNING, c!("Flag -%s is DEPRECATED! Interpreting it as `-%s %s` instead."), flag_name(linker), PARAM_FLAG_NAME, codegen_arg);
     }
 
-    let gen = match target {
-        Target::Gas_x86_64_Linux   |
-        Target::Gas_x86_64_Windows |
-        Target::Gas_x86_64_Darwin  => codegen::gas_x86_64::new(&mut c.arena, da_slice(*codegen_args)),
-        Target::Gas_AArch64_Linux  |
-        Target::Gas_AArch64_Darwin => codegen::gas_aarch64::new(&mut c.arena, da_slice(*codegen_args)),
-        Target::Uxn                => codegen::uxn::new(&mut c.arena, da_slice(*codegen_args)),
-        Target::Mos6502_Posix      => codegen::mos6502::new(&mut c.arena, da_slice(*codegen_args)),
-        Target::ILasm_Mono         => codegen::ilasm_mono::new(&mut c.arena, da_slice(*codegen_args)),
-    }?;
+    let gen = (target.api.new)(&mut c.arena, da_slice(*codegen_args))?;
 
     if input_paths.count == 0 {
         usage();
@@ -1381,12 +1373,12 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     }
 
     let program_path = if (*output_path).is_null() {
-        temp_sprintf(c!("%s%s"), temp_strip_file_ext(*input_paths.items), target.file_ext())
+        temp_sprintf(c!("%s%s"), temp_strip_file_ext(*input_paths.items), target.api.file_ext)
     } else {
         if get_file_ext(*output_path).is_some() {
             *output_path
         } else {
-            temp_sprintf(c!("%s%s"), *output_path, target.file_ext())
+            temp_sprintf(c!("%s%s"), *output_path, target.api.file_ext)
         }
     };
 
@@ -1404,129 +1396,13 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     // to that object should be computed as `temp_sprintf("%s.o", garbase_base)`.
     let garbage_base = get_garbage_base(program_path, target)?;
 
-    match target {
-        Target::Gas_AArch64_Linux => {
-            let os = targets::Os::Linux;
-
-            if !*nobuild {
-                codegen::gas_aarch64::generate_program(
-                    gen, &c.program, program_path, garbage_base, os,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_aarch64::run_program(
-                    gen, program_path, da_slice(run_args), os,
-                )?;
-            }
-        }
-        Target::Gas_AArch64_Darwin => {
-            let os = targets::Os::Darwin;
-
-            if !*nobuild {
-                codegen::gas_aarch64::generate_program(
-                    gen, &c.program, program_path, garbage_base, os,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_aarch64::run_program(
-                    gen, program_path, da_slice(run_args), os,
-                )?;
-            }
-        }
-        Target::Gas_x86_64_Linux => {
-            let os = targets::Os::Linux;
-
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    gen, &c.program, program_path, garbage_base, os,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(
-                    gen, program_path, da_slice(run_args), os,
-                )?;
-            }
-        }
-        Target::Gas_x86_64_Windows => {
-            let os = targets::Os::Windows;
-
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    gen, &c.program, program_path, garbage_base, os,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(
-                    gen, program_path, da_slice(run_args), os,
-                )?;
-            }
-        }
-        Target::Gas_x86_64_Darwin => {
-            let os = targets::Os::Darwin;
-
-            if !*nobuild {
-                codegen::gas_x86_64::generate_program(
-                    gen, &c.program, program_path, garbage_base, os,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::gas_x86_64::run_program(
-                    gen, program_path, da_slice(run_args), os,
-                )?;
-            }
-        }
-        Target::Uxn => {
-            if !*nobuild {
-                codegen::uxn::generate_program(
-                    gen, &c.program, program_path, garbage_base,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::uxn::run_program(
-                    gen, program_path, da_slice(run_args),
-                )?;
-            }
-        }
-        Target::Mos6502_Posix => {
-            if !*nobuild {
-                codegen::mos6502::generate_program(
-                    gen, &c.program, program_path, garbage_base,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::mos6502::run_program(
-                    gen, program_path, da_slice(run_args),
-                )?;
-            }
-        }
-        Target::ILasm_Mono => {
-            if !*nobuild {
-                codegen::ilasm_mono::generate_program(
-                    gen, &c.program, program_path, garbage_base,
-                    *nostdlib, *debug,
-                )?;
-            }
-
-            if *run {
-                codegen::ilasm_mono::run_program(
-                    gen, program_path, da_slice(run_args),
-                )?;
-            }
-        }
+    if !*nobuild {
+        (target.api.build)(gen, &c.program, program_path, garbage_base, *nostdlib, *debug)?;
     }
+
+    if *run {
+        (target.api.run)(gen, program_path, da_slice(run_args))?
+    }
+
     Some(())
 }

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -6,10 +6,10 @@ use crate::crust::assoc_lookup_cstr;
 use crate::ir::*;
 use crate::lexer::*;
 use crate::missingf;
-use crate::targets::Os;
-use crate::codegen::*;
+use crate::targets::{Os, TargetAPI};
 use crate::shlex::*;
 use crate::arena;
+use crate::params::*;
 
 pub unsafe fn align_bytes(bytes: usize, alignment: usize) -> usize {
     let rem = bytes%alignment;
@@ -502,6 +502,32 @@ struct Gas_AArch64 {
     link_args: *const c_char,
     output: String_Builder,
     cmd: Cmd,
+}
+
+pub unsafe fn get_apis(targets: *mut Array<TargetAPI>) {
+    da_append(targets, TargetAPI {
+        name: c!("gas-aarch64-linux"),
+        file_ext: c!(""),
+        new,
+        build: |gen, program, program_path, garbage_base, nostdlib, debug| {
+            generate_program(gen, program, program_path, garbage_base, Os::Linux, nostdlib, debug)
+        },
+        run: |gen, program_path, run_args| {
+            run_program(gen, program_path, run_args, Os::Linux)
+        },
+    });
+
+    da_append(targets, TargetAPI {
+        name: c!("gas-aarch64-darwin"),
+        file_ext: c!(""),
+        new,
+        build: |gen, program, program_path, garbage_base, nostdlib, debug| {
+            generate_program(gen, program, program_path, garbage_base, Os::Darwin, nostdlib, debug)
+        },
+        run: |gen, program_path, run_args| {
+            run_program(gen, program_path, run_args, Os::Darwin)
+        },
+    });
 }
 
 pub unsafe fn new(a: *mut arena::Arena, args: *const [*const c_char]) -> Option<*mut c_void> {

--- a/src/codegen/ilasm_mono.rs
+++ b/src/codegen/ilasm_mono.rs
@@ -4,8 +4,9 @@ use crate::crust::libc::*;
 use crate::lexer::*;
 use crate::missingf;
 use crate::ir::*;
-use crate::codegen::*;
 use crate::arena;
+use crate::targets::TargetAPI;
+use crate::params::*;
 
 pub unsafe fn load_arg(loc: Loc, arg: Arg, output: *mut String_Builder, data: *const [u8]) {
     match arg {
@@ -185,6 +186,16 @@ pub unsafe fn usage(params: *const [Param]) {
 struct ILasm_Mono {
     output: String_Builder,
     cmd: Cmd,
+}
+
+pub unsafe fn get_apis(targets: *mut Array<TargetAPI>) {
+    da_append(targets, TargetAPI {
+        name: c!("ilasm-mono"),
+        file_ext: c!(".exe"),
+        new,
+        build: generate_program,
+        run: run_program,
+    });
 }
 
 pub unsafe fn new(a: *mut arena::Arena, args: *const [*const c_char]) -> Option<*mut c_void> {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,100 +1,34 @@
-pub mod gas_aarch64;
-pub mod gas_x86_64;
-pub mod mos6502;
-pub mod uxn;
-pub mod ilasm_mono;
+macro_rules! codegens {
+    ($($codegen:ident,)*) => {
+        pub unsafe fn load_targets() -> Option<crate::nob::Array<crate::targets::Target>> {
+            use crate::crust::libc::*;
+            use crate::nob::*;
+            use crate::targets::*;
+            use core::mem::zeroed;
+            use core::ffi::*;
 
-use core::ffi::*;
-use core::ptr;
-use crate::crust::libc::*;
-use crate::nob::*;
+            let mut targets: Array<Target> = zeroed();
+            let mut apis: Array<TargetAPI> = zeroed();
 
-pub const CODEGEN_FLAG_NAME: *const c_char = c!("C");
+            $(
+                crate::codegen::$codegen::get_apis(&mut apis);
+                register_apis(&mut targets, da_slice(apis), c!(stringify!($codegen)))?;
+                apis.count = 0;
+            )*
 
-#[derive(Clone, Copy)]
-pub enum ParamValue {
-    Flag   { var: *mut bool                                  },
-    String { var: *mut *const c_char, default: *const c_char },
-    Hex    { var: *mut u64,           default: u64           },
-}
-
-#[derive(Clone, Copy)]
-pub struct Param {
-    pub name:        *const c_char,
-    pub description: *const c_char,
-    pub value:       ParamValue,
-}
-
-pub unsafe fn parse_args(params: *const [Param], args: *const[*const c_char]) -> Result<(), *const c_char> {
-    for j in 0..params.len() {
-        let param = (*params)[j];
-        match param.value {
-            ParamValue::Flag   {var}          => *var = false,
-            ParamValue::String {var, default} => *var = default,
-            ParamValue::Hex    {var, default} => *var = default,
+            free(apis.items as _);
+            Some(targets)
         }
-    }
 
-    'args: for i in 0..args.len() {
-        let arg = (*args)[i];
-        let equal = strchr(arg, '=' as i32);
-        let (key, value) = if equal.is_null() {
-            (arg, ptr::null())
-        } else {
-            (temp_sprintf(c!("%.*s"), equal.offset_from(arg), arg) as *const c_char, equal.wrapping_add(1))
-        };
-        for j in 0..params.len() {
-            let param = (*params)[j];
-            if strcmp(param.name, key) == 0 {
-                match param.value {
-                    ParamValue::Flag{var, ..} => {
-                        if !value.is_null() {
-                            return Err(temp_sprintf(c!("%s is a flag and may not have a value"), key));
-                        }
-                        *var = true;
-                    }
-                    ParamValue::String{var, ..} => {
-                        *var = value;
-                    }
-                    ParamValue::Hex{var, ..} => {
-                        if value.is_null() {
-                            return Err(temp_sprintf(c!("%s expects a hexadecimal value"), key));
-                        }
-                        let mut endptr: *mut c_char = ptr::null_mut();
-                        *var = strtoull(value, &mut endptr, 16);
-                        if endptr as *const c_char == value || *endptr != 0 {
-                            return Err(temp_sprintf(c!("%s expects a hexadecimal value"), key));
-                        }
-                    }
-                }
-                continue 'args
-            }
-        }
-        return Err(temp_sprintf(c!("Unknown codegen parameter %s"), key));
-    }
-    Ok(())
+        $(pub mod $codegen;)*
+    };
 }
 
-pub unsafe fn print_params_help(params: *const [Param]) {
-    for i in 0..params.len() {
-        let param = (*params)[i];
-        match param.value {
-            ParamValue::Flag{..} => {
-                fprintf(stderr(), c!("    -%s %s\n"), CODEGEN_FLAG_NAME, param.name);
-                fprintf(stderr(), c!("        %s\n"), param.description);
-            }
-            ParamValue::String{default, ..} => {
-                fprintf(stderr(), c!("    -%s %s=\"<str>\"\n"), CODEGEN_FLAG_NAME, param.name);
-                fprintf(stderr(), c!("        %s\n"), param.description);
-                if !default.is_null() && *default != 0 {
-                    fprintf(stderr(), c!("        Default: %s\n"), default);
-                }
-            },
-            ParamValue::Hex{default, ..} => {
-                fprintf(stderr(), c!("    -%s %s=<hex>\n"), CODEGEN_FLAG_NAME, param.name);
-                fprintf(stderr(), c!("        %s\n"), param.description);
-                fprintf(stderr(), c!("        Default: %lX\n"), default);
-            }
-        };
-    }
+codegens! {
+    // TODO: maybe instead of gas_ the prefix should be gnu_, 'cause that makes more sense.
+    gas_x86_64,
+    gas_aarch64,
+    uxn,
+    mos6502,
+    ilasm_mono,
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -31,4 +31,5 @@ codegens! {
     uxn,
     mos6502,
     ilasm_mono,
+    noop,
 }

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -15,7 +15,8 @@ use crate::diagf;
 use crate::crust::libc::*;
 use crate::lexer::{is_identifier_start, is_identifier};
 use crate::arena::{self, Arena};
-use crate::codegen::*;
+use crate::targets::TargetAPI;
+use crate::params::*;
 
 // TODO: does this have to be a macro?
 macro_rules! instr_enum {
@@ -1553,6 +1554,16 @@ struct Mos6502 {
     load_offset: u64,
     out: String_Builder,
     cmd: Cmd,
+}
+
+pub unsafe fn get_apis(targets: *mut Array<TargetAPI>) {
+    da_append(targets, TargetAPI {
+        name: c!("6502-posix"),
+        file_ext: c!(".6502"),
+        new,
+        build: generate_program,
+        run: run_program,
+    });
 }
 
 pub unsafe fn new(a: *mut arena::Arena, args: *const [*const c_char]) -> Option<*mut c_void> {

--- a/src/codegen/noop.rs
+++ b/src/codegen/noop.rs
@@ -1,0 +1,9 @@
+//! Smallest possible codegen that compiles
+
+use crate::targets::TargetAPI;
+use crate::nob::Array;
+
+// Compiler expects only get_apis()
+pub unsafe fn get_apis(_targets: *mut Array<TargetAPI>) {
+    // Export no APIs
+}

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -7,9 +7,10 @@ use crate::lexer::Loc;
 use crate::missingf;
 use crate::diagf;
 use crate::arena;
-use crate::codegen::*;
 use crate::lexer;
 use crate::lexer::{Token, loc};
+use crate::targets::TargetAPI;
+use crate::params::*;
 
 // UXN memory map
 // 0x0000 - 0x00ff - zero page
@@ -161,6 +162,16 @@ struct Uxn {
     runner: Uxn_Runner,
     output: String_Builder,
     cmd: Cmd,
+}
+
+pub unsafe fn get_apis(targets: *mut Array<TargetAPI>) {
+    da_append(targets, TargetAPI {
+        name: c!("uxn"),
+        file_ext: c!(".rom"),
+        new,
+        build: generate_program,
+        run: run_program,
+    });
 }
 
 pub unsafe fn new(a: *mut arena::Arena, args: *const [*const c_char]) -> Option<*mut c_void> {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -135,7 +135,6 @@ pub struct Program {
     pub asm_funcs: Array<AsmFunc>,
 }
 
-
 pub unsafe fn dump_arg_call(arg: Arg, output: *mut String_Builder) {
     match arg {
         Arg::RefExternal(name) | Arg::External(name) => {

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,94 @@
+use core::ffi::*;
+use core::ptr;
+use crate::crust::libc::*;
+use crate::nob::*;
+
+pub const PARAM_FLAG_NAME: *const c_char = c!("C");
+
+#[derive(Clone, Copy)]
+pub enum ParamValue {
+    Flag   { var: *mut bool                                  },
+    String { var: *mut *const c_char, default: *const c_char },
+    Hex    { var: *mut u64,           default: u64           },
+}
+
+#[derive(Clone, Copy)]
+pub struct Param {
+    pub name:        *const c_char,
+    pub description: *const c_char,
+    pub value:       ParamValue,
+}
+
+pub unsafe fn parse_args(params: *const [Param], args: *const[*const c_char]) -> Result<(), *const c_char> {
+    for j in 0..params.len() {
+        let param = (*params)[j];
+        match param.value {
+            ParamValue::Flag   {var}          => *var = false,
+            ParamValue::String {var, default} => *var = default,
+            ParamValue::Hex    {var, default} => *var = default,
+        }
+    }
+
+    'args: for i in 0..args.len() {
+        let arg = (*args)[i];
+        let equal = strchr(arg, '=' as i32);
+        let (key, value) = if equal.is_null() {
+            (arg, ptr::null())
+        } else {
+            (temp_sprintf(c!("%.*s"), equal.offset_from(arg), arg) as *const c_char, equal.wrapping_add(1))
+        };
+        for j in 0..params.len() {
+            let param = (*params)[j];
+            if strcmp(param.name, key) == 0 {
+                match param.value {
+                    ParamValue::Flag{var, ..} => {
+                        if !value.is_null() {
+                            return Err(temp_sprintf(c!("%s is a flag and may not have a value"), key));
+                        }
+                        *var = true;
+                    }
+                    ParamValue::String{var, ..} => {
+                        *var = value;
+                    }
+                    ParamValue::Hex{var, ..} => {
+                        if value.is_null() {
+                            return Err(temp_sprintf(c!("%s expects a hexadecimal value"), key));
+                        }
+                        let mut endptr: *mut c_char = ptr::null_mut();
+                        *var = strtoull(value, &mut endptr, 16);
+                        if endptr as *const c_char == value || *endptr != 0 {
+                            return Err(temp_sprintf(c!("%s expects a hexadecimal value"), key));
+                        }
+                    }
+                }
+                continue 'args
+            }
+        }
+        return Err(temp_sprintf(c!("Unknown codegen parameter %s"), key));
+    }
+    Ok(())
+}
+
+pub unsafe fn print_params_help(params: *const [Param]) {
+    for i in 0..params.len() {
+        let param = (*params)[i];
+        match param.value {
+            ParamValue::Flag{..} => {
+                fprintf(stderr(), c!("    -%s %s\n"), PARAM_FLAG_NAME, param.name);
+                fprintf(stderr(), c!("        %s\n"), param.description);
+            }
+            ParamValue::String{default, ..} => {
+                fprintf(stderr(), c!("    -%s %s=\"<str>\"\n"), PARAM_FLAG_NAME, param.name);
+                fprintf(stderr(), c!("        %s\n"), param.description);
+                if !default.is_null() && *default != 0 {
+                    fprintf(stderr(), c!("        Default: %s\n"), default);
+                }
+            },
+            ParamValue::Hex{default, ..} => {
+                fprintf(stderr(), c!("    -%s %s=<hex>\n"), PARAM_FLAG_NAME, param.name);
+                fprintf(stderr(), c!("        %s\n"), param.description);
+                fprintf(stderr(), c!("        Default: %lX\n"), default);
+            }
+        };
+    }
+}

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,59 +1,70 @@
 use core::ffi::*;
 use crate::strcmp;
+use crate::ir::Program;
+use crate::arena;
+use crate::nob::*;
 
 // TODO: add wasm target
 //   Don't touch this TODO! @rexim wants to stream it!
-enum_with_order! {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum Target in TARGET_ORDER {
-        // TODO: maybe instead of Gas_ the prefix should be Gnu_, 'cause that makes more sense.
-        Gas_x86_64_Windows,
-        Gas_x86_64_Linux,
-        Gas_x86_64_Darwin,
-        Gas_AArch64_Linux,
-        Gas_AArch64_Darwin,
-        Uxn,
-        Mos6502_Posix,
-        ILasm_Mono,
-    }
+
+#[derive(Clone, Copy)]
+pub struct Target {
+    pub codegen_name: *const c_char,
+    pub api: TargetAPI,
 }
 
 impl Target {
-    pub unsafe fn file_ext(self) -> *const c_char {
-        match self {
-            Self::Gas_x86_64_Windows => c!(".exe"),
-            Self::Gas_x86_64_Linux   => c!(""),
-            Self::Gas_x86_64_Darwin  => c!(""),
-            Self::Gas_AArch64_Linux  => c!(""),
-            Self::Gas_AArch64_Darwin => c!(""),
-            Self::Uxn                => c!(".rom"),
-            Self::Mos6502_Posix      => c!(".6502"),
-            Self::ILasm_Mono         => c!(".exe"),
-        }
-    }
-
-    pub unsafe fn name(self) -> *const c_char {
-        match self {
-            Self::Gas_x86_64_Windows  => c!("gas-x86_64-windows"),
-            Self::Gas_x86_64_Linux    => c!("gas-x86_64-linux"),
-            Self::Gas_x86_64_Darwin   => c!("gas-x86_64-darwin"),
-            Self::Gas_AArch64_Linux   => c!("gas-aarch64-linux"),
-            Self::Gas_AArch64_Darwin  => c!("gas-aarch64-darwin"),
-            Self::Uxn                 => c!("uxn"),
-            Self::Mos6502_Posix       => c!("6502-posix"),
-            Self::ILasm_Mono          => c!("ilasm-mono"),
-        }
-    }
-
-    pub unsafe fn by_name(name: *const c_char) -> Option<Self> {
-        for i in 0..TARGET_ORDER.len() {
-            let target = (*TARGET_ORDER)[i];
-            if strcmp(target.name(), name) == 0 {
+    pub unsafe fn by_name(targets: *const [Target], name: *const c_char) -> Option<Target> {
+        for i in 0..targets.len() {
+            let target = (*targets)[i];
+            if strcmp(target.api.name, name) == 0 {
                 return Some(target);
             }
         }
         None
     }
+}
+
+pub unsafe fn register_apis(targets: *mut Array<Target>, apis: *const [TargetAPI], codegen_name: *const c_char) -> Option<()> {
+    for i in 0..apis.len() {
+        let api = (*apis)[i];
+        for j in 0..(*targets).count {
+            let target = *(*targets).items.add(j);
+            if strcmp(target.api.name, api.name) == 0 {
+                if strcmp(target.codegen_name, codegen_name) == 0 {
+                    log(Log_Level::ERROR, c!("TARGET NAME CONFLICT: Codegen %s defines target %s more than once"), codegen_name, api.name);
+                } else {
+                    log(Log_Level::ERROR, c!("TARGET NAME CONFLICT: Codegens %s and %s define the same target %s"), codegen_name, target.codegen_name, api.name);
+                }
+                return None;
+            }
+        }
+        da_append(targets, Target {codegen_name, api});
+    }
+    Some(())
+}
+
+#[derive(Clone, Copy)]
+pub struct TargetAPI {
+    pub name: *const c_char,
+    pub file_ext: *const c_char,
+    pub new: unsafe fn(
+        a: *mut arena::Arena,
+        args: *const [*const c_char]
+    ) -> Option<*mut c_void>,
+    pub build: unsafe fn(
+        gen: *mut c_void,
+        program: *const Program,
+        program_path: *const c_char,
+        garbage_base: *const c_char,
+        nostdlib: bool,
+        debug: bool,
+    ) -> Option<()>,
+    pub run: unsafe fn(
+        gen: *mut c_void,
+        program_path: *const c_char,
+        run_args: *const [*const c_char],
+    ) -> Option<()>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
This is a pivotal PR that fundamentally changes the interface between the compiler and the codegens. Now the codegens are way more decoupled from the compiler and provide their APIs as a structure of function pointers.

@yui-915 @deniska @Miezekatze64 @seija-amanojaku please let me know if you see any problems in this approach.