### PR TITLE
Add build folder as a libb search path

### DIFF
--- a/src/crust.rs
+++ b/src/crust.rs
@@ -114,6 +114,7 @@ pub mod libc {
         pub fn tolower(c: c_int) -> c_int;
         pub fn toupper(c: c_int) -> c_int;
         pub fn qsort(base: *mut c_void, nmemb: usize, size: usize, compar: unsafe extern "C" fn(*const c_void, *const c_void) -> c_int);
+        pub fn dirname(path: *const c_char) -> *const c_char;
     }
 
     // count is the amount of items, not bytes


### PR DESCRIPTION
Fixes #278, and provides a `add_libb_files` as a short way to add a directory to the libb list