### PR TITLE
Migration from Makefile to Crust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+bbuild
 build/

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ test: $(BUILD)/b $(BUILD)/btest $(BUILD)/libb/
 .PHONY: mingw32-all
 mingw32-all: $(BUILD)/b.exe $(BUILD)/btest.exe $(BUILD)/libb/
 
+bbuild: $(POSIX_OBJS)
+	rustc $(CRUST_FLAGS) -L $(BUILD) -C link-args="$(POSIX_OBJS) $(LDFLAGS)" build.rs -o bbuild
+
 $(BUILD)/b: $(RSS) $(POSIX_OBJS) $(SRC)/codegen/.INDEX.rs | $(BUILD)
 	rustc $(CRUST_FLAGS) -L $(BUILD) -C link-args="$(POSIX_OBJS) $(LDFLAGS)" $(SRC)/b.rs -o $(BUILD)/b
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,132 @@
+#![no_main]
+#![no_std]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(unused_macros)]
+
+#[macro_use]
+#[path = "./src/crust.rs"]
+pub mod crust;
+#[macro_use]
+#[path = "./src/nob.rs"]
+pub mod nob;
+
+use core::mem::zeroed;
+use core::ffi::c_char;
+use crate::nob::*;
+use crust::libc::*;
+
+pub unsafe fn select_object_files(
+    build_path: *const c_char,
+    os_target: *const c_char,
+    objects_to_build: &[*const c_char],
+    object_file_names: &mut Array<*const c_char>,
+    c_file_names: &mut Array<*const c_char>,
+) -> bool {
+    let thirdparty_path = c!("./thirdparty");
+    for i in 0..objects_to_build.len() {
+        da_append(c_file_names, temp_sprintf(c!("%s/%s.c"), thirdparty_path, objects_to_build[i]));
+        if strcmp(os_target, c!("linux")) == 0 {
+            da_append(object_file_names, temp_sprintf(c!("%s/%s.posix.o"), build_path, objects_to_build[i]));
+        } else if strcmp(os_target, c!("windows")) == 0 {
+            da_append(object_file_names, temp_sprintf(c!("%s/%s.mingw32.o"), build_path, objects_to_build[i]));
+        } else {
+            log(Log_Level::ERROR, c!("The target '%s' is not available. You should build it yourself I guess..."), os_target);
+            return false;
+        }
+    }
+    return true;
+}
+
+pub unsafe fn build_objects(
+    cmd: &mut Cmd,
+    os_target: *const c_char,
+    object_file_names: &mut Array<*const c_char>,
+    c_file_names: &mut Array<*const c_char>,
+    ld_flags: *const c_char,
+) -> bool {
+    assert!(object_file_names.count == c_file_names.count);
+
+    // TODO: This should easily be parallelizable - but I'm too lazy to do it right now.
+    //   Nextness (2025-08-12 22:25:40)
+    if strcmp(os_target, c!("linux")) == 0 {
+        for i in 0..object_file_names.count {
+            cmd_append! {
+                cmd,
+                c!("cc"), c!("-fPIC"), c!("-g"),
+                c!("-c"), *c_file_names.items.add(i),
+                c!("-o"), *object_file_names.items.add(i),
+                ld_flags,
+            }
+            if !cmd_run_sync_and_reset(cmd) { return false };
+        }
+    } else if strcmp(os_target, c!("windows")) == 0 {
+        for i in 0..object_file_names.count {
+            cmd_append! {
+                cmd,
+                c!("x86_64-w64-mingw32-gcc"), c!("-fPIC"), c!("-g"),
+                c!("-c"), *c_file_names.items.add(i),
+                c!("-o"), *object_file_names.items.add(i),
+            }
+            if !cmd_run_sync_and_reset(cmd) { return false };
+        }
+    } else {
+        log(Log_Level::ERROR, c!("The target '%s' is not available. You should build it yourself I guess..."), os_target);
+        return false
+    }
+
+    return true;
+}
+
+pub unsafe fn build_b(
+    cmd: &mut Cmd,
+    src_path: *const c_char,
+    build_path: *const c_char,
+    object_file_names: &mut Array<*const c_char>,
+    crust_flags: &[*const c_char],
+    ld_flags: &[*const c_char],
+) -> bool {
+
+    da_append(cmd, c!("rustc"));
+    da_append_many(cmd, crust_flags);
+
+    da_append(cmd, temp_sprintf(c!("-L%s"), build_path));
+    for i in 0..object_file_names.count {
+        let link_args = temp_sprintf(c!("-Clink-args=%s"), *object_file_names.items.add(i));
+        da_append(cmd, link_args);
+    }
+
+    da_append_many(cmd, ld_flags);
+    da_append(cmd, temp_sprintf(c!("%s/b.rs"), src_path));
+    da_append(cmd, c!("-o"));
+    da_append(cmd, temp_sprintf(c!("%s/b"), build_path));
+    if !cmd_run_sync_and_reset(cmd) { return false };
+
+    return true;
+}
+
+pub unsafe fn main(mut _argc: i32, mut _argv: *mut*mut c_char) -> Option<()> {
+    const src_path: *const c_char = c!("src");
+    const build_path: *const c_char = c!("build");
+
+    if !mkdir_if_not_exists(build_path) { return None }
+
+    // TODO: memory leak
+    let mut cmd: Cmd = zeroed();
+    let mut object_file_names: Array<*const c_char> = zeroed();
+    let mut c_file_names:  Array<*const c_char> = zeroed();
+
+    let os_target = c!("linux");
+    const objects_to_build: &[*const c_char] = c_many!(
+        "nob", "flag", "glob", "libc", "arena", "time", "jim", "jimp", "shlex"
+    );
+    let crust_flags = c_many!("-g", "--edition=2021", "-Copt-level=0", "-Cpanic=abort");
+    let ld_flags = c_many!("-lc", "-lgcc");
+
+    if !select_object_files(build_path, os_target, objects_to_build, &mut object_file_names, &mut c_file_names) { return None; }
+    if !build_objects(&mut cmd, os_target, &mut object_file_names, &mut c_file_names, c!("-lc -lgcc")) { return None; }
+    build_b(&mut cmd, src_path, build_path, &mut object_file_names, crust_flags, ld_flags);
+
+    return Some(());
+}
+

--- a/src/crust.rs
+++ b/src/crust.rs
@@ -11,6 +11,14 @@ macro_rules! c {
 }
 
 #[macro_export]
+macro_rules! c_many {
+    ($($l:expr),+ $(,)?) => {
+        &[$(concat!($l, "\0").as_ptr() as *const c_char),*]
+    };
+}
+
+
+#[macro_export]
 macro_rules! enum_with_order {
     (
         #[derive($($traits:tt)*)]


### PR DESCRIPTION
Hello Mr Tsoding. Hopefully you find this PR somewhat relevant. It contains my perspective on how we could migrate from Makefiles to Crust for the build system.

This initial commit has the basic idea of generating the object files and b itself, without flags. Before committing strongly to any architecture and possibly wasting time, I would like to know your input.

Here are some additional considerations:
1. The inclusion of build.rs at the root may not be the greatest, specially with `#[path = "./src/crust.rs"]`, but it technically works.
1. Makefile as the bootstrap for `bbuild`, and then all subsequent compilations using it.
1. Flags that I feel are useful when we using `bbuild`. There is an exponential number of flags that I can think of, but for the sake of this initial conversation I will keep it simple and similar to what is in the Makefile.
    1. `bbuild --all`: builds everything.
    2. `bbuild --test`: builds tests.
    4. `bbuild --os-target <some_os>`: obviously targets the os. The default should always be the current os.
    5. `bbuild --back-end <some_back_end>`: selects the backend. The default should be the one available in the PC.

