### PR TITLE
Fix ref.b test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           make -B
       - name: Run Tests
         run: |
-          PATH=$(realpath uxn11/bin):$PATH ./build/btest -t *linux* -t *windows*
+          ./build/btest -t *linux* -t *windows*
   ubuntu-uxn:
     runs-on: ubuntu-latest
     steps:
@@ -33,15 +33,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qq -y clang make
-          git clone https://git.sr.ht/~rabbits/uxn11
-          cd uxn11
-          make cli
+          git clone https://git.sr.ht/~rabbits/uxn
+          cd uxn
+          git checkout b56cb3501b741410188b00ffcac9010cfbe1783c
+          clang -std=c89 -Wall -Wno-unknown-pragmas src/uxn.c src/devices/system.c src/devices/console.c src/devices/file.c src/devices/datetime.c src/uxncli.c -o uxncli
       - name: Build Toolchain
         run: |
           make -B
       - name: Run Tests
         run: |
-          PATH=$(realpath uxn11/bin):$PATH ./build/btest -t uxn
+          PATH=$(realpath uxn/):$PATH ./build/btest -t uxn
   ubuntu-6502-posix:
     runs-on: ubuntu-latest
     steps:

--- a/tests/ref.b
+++ b/tests/ref.b
@@ -28,11 +28,12 @@ test2() {
 
 test3() {
 	extrn printf, malloc;
-	auto xs;
+	auto W, xs;
 
-	xs = malloc(8*2);
-	xs[0*8] = 13;
-	xs[1*8] = 42;
+	W = &0[1];
+	xs = malloc(W*2);
+	xs[0] = 13;
+	*(xs+W) = 42;
 
 	// "E1[E2] is identical to *(E1+E2)"
 	// "&*x is identically x"
@@ -40,8 +41,8 @@ test3() {
 	// check generated IR to confirm that
 	printf(
 		"xs: [%d, %d]\n",
-		read(xs + 0*8),
-		read(&xs[1*8])
+		read(xs),
+		read(&xs[1])
 	);
 }
 


### PR DESCRIPTION
The `ref.b` test was written before indexing became word-based, and didn't get updated afterwards.
it worked on all of the current targets because they don't have very stricts memory bounds check, but fails on the javascript target I'm working on because it tries to access unallocated memory.