### PR TITLE
Add C-style initialization for autovars declaration

### DIFF
--- a/docs/bext.md
+++ b/docs/bext.md
@@ -56,6 +56,20 @@ Some targets like `gas-aarch64-darwin` have a different calling convention for v
 this is needed to make the compiler use the correct calling convention. \
 the syntax is `__variadic__(function_name, number_of_fixed_args);`
 
+## C-style initializers
+
+```c
+main() {
+    auto xs 5 = {1, 2, 3, 4, 5};
+    auto i = 0; while (i < 5) {
+        printf("xs[%lld] = %lld\n", i, xs[i]);
+        i += 1;
+    }
+}
+```
+
+Allows directly initializing automatic variables as you declare them.
+
 <!--
     TODO: hex-literals and C++ style comments are currently considered deviations
     and not extensions, thus disabled in historical mode, which is a bug.

--- a/src/b.rs
+++ b/src/b.rs
@@ -725,7 +725,7 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 let name = arena::strdup(&mut (*c).arena, (*l).string);
                 let index = allocate_auto_var(&mut (*c).auto_vars_ator);
                 declare_var(c, name, (*l).loc, Storage::Auto {index})?;
-                get_and_expect_tokens(l, &[Token::SemiColon, Token::Comma, Token::IntLit, Token::CharLit])?;
+                get_and_expect_tokens(l, &[Token::SemiColon, Token::Comma, Token::IntLit, Token::CharLit, Token::Eq])?;
                 if (*l).token == Token::IntLit || (*l).token == Token::CharLit {
                     let size = (*l).int_number as usize;
                     if size == 0 {
@@ -739,6 +739,34 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                     //   See TODO(2025-06-05 17:45:36)
                     let arg = Arg::RefAutoVar(index + size);
                     push_opcode(Op::AutoAssign {index, arg}, (*l).loc, c);
+                    get_and_expect_tokens(l, &[Token::SemiColon, Token::Comma, Token::Eq])?;
+
+                    if (*l).token == Token::Eq {
+                        let eq_loc = (*l).loc;
+                        get_and_expect_token(l, Token::OCurly)?;
+                        let saved_point = (*l).parse_point;
+                        lexer::get_token(l)?;
+                        if (*l).token != Token::CCurly {
+                            (*l).parse_point = saved_point;
+                            let mut count = 0;
+                            while (*l).token != Token::CCurly {
+                                let loc = (*l).loc;
+                                let (arg, _) = compile_expression(l, c)?;
+                                push_opcode(Op::AutoAssign {index: index + size - count, arg}, loc, c);
+                                count += 1;
+                                get_and_expect_tokens(l, &[Token::CCurly, Token::Comma])?;
+                            }
+                            if count > size {
+                                diagf!(eq_loc, c!("ERROR: Automatic vector of size %llu cannot be initialized with %llu elements\n"), size, count);
+                                bump_error_count(c)?;
+                            }
+                        }
+                        get_and_expect_tokens(l, &[Token::SemiColon, Token::Comma])?;
+                    }
+                } else if (*l).token == Token::Eq {
+                    let loc = (*l).loc;
+                    let (arg, _) = compile_expression(l, c)?;
+                    push_opcode(Op::AutoAssign {index, arg}, loc, c);
                     get_and_expect_tokens(l, &[Token::SemiColon, Token::Comma])?;
                 }
             }

--- a/tests.json
+++ b/tests.json
@@ -2147,5 +2147,61 @@
         "expected_stdout": "",
         "state": "Disabled",
         "comment": "Doesn't make sense for this target"
+    },
+    {
+        "case": "auto_initializer",
+        "target": "gas-x86_64-linux",
+        "expected_stdout": "69\nxs[0]: 1\nxs[1]: 4\nxs[2]: 9\nxs[3]: 16\nxs[4]: 25\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "ilasm-mono",
+        "expected_stdout": "",
+        "state": "Enabled",
+        "comment": "Failed to build on record"
+    },
+    {
+        "case": "auto_initializer",
+        "target": "gas-aarch64-linux",
+        "expected_stdout": "69\nxs[0]: 1\nxs[1]: 4\nxs[2]: 9\nxs[3]: 16\nxs[4]: 25\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "gas-aarch64-darwin",
+        "expected_stdout": "69\nxs[0]: 1\nxs[1]: 4\nxs[2]: 9\nxs[3]: 16\nxs[4]: 25\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "gas-x86_64-windows",
+        "expected_stdout": "69\r\nxs[0]: 1\r\nxs[1]: 4\r\nxs[2]: 9\r\nxs[3]: 16\r\nxs[4]: 25\r\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "gas-x86_64-darwin",
+        "expected_stdout": "69\nxs[0]: 1\nxs[1]: 4\nxs[2]: 9\nxs[3]: 16\nxs[4]: 25\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "6502-posix",
+        "expected_stdout": "69\r\nxs[0]: 1\r\nxs[1]: 4\r\nxs[2]: 9\r\nxs[3]: 16\r\nxs[4]: 25\r\n",
+        "state": "Enabled",
+        "comment": ""
+    },
+    {
+        "case": "auto_initializer",
+        "target": "uxn",
+        "expected_stdout": "69\nxs[0]: 1\nxs[1]: 4\nxs[2]: 9\nxs[3]: 16\nxs[4]: 25\n",
+        "state": "Enabled",
+        "comment": ""
     }
 ]

--- a/tests/auto_initializer.b
+++ b/tests/auto_initializer.b
@@ -1,0 +1,10 @@
+main() {
+  auto x = 34 + 35;
+  printf("%d\n", x);
+
+  auto xs 5 = {1, 2+2, 3*3, 32/2, 0x19};
+  auto i = 0; while (i < 5) {
+    printf("xs[%d]: %d\n", i, xs[i]);
+    i += 1;
+  }
+}


### PR DESCRIPTION
This is an extension, aiming to make using the language more convenient, by not having to duplicate the variable name when trying to declare and assign a value to it, example:
```cpp
auto thing; thing = value;
```
would become
```cpp
auto thing = value;
```

this was attempted in #170 but the author abounded the PR.

about automatic vector initialization syntax, `auto list 3 = {1, 2, 3};` seems natural, but it does create a discrepancy with the regular assign binary operation, other options would be:
* `auto list 3 {1, 2, 3};`
* just don't support initialization for vectors

also should we update all the examples/tests to use the new syntax or leave then as-is ? 